### PR TITLE
Adjust ESLint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,42 @@
 module.exports = {
   root: true,
 
-  extends: ['@metamask/eslint-config'],
+  extends: ['@metamask/eslint-config', '@metamask/eslint-config-nodejs'],
+
+  rules: {
+    // This makes integration tests easier to read by allowing setup code and
+    // assertions to be grouped together better
+    'padding-line-between-statements': [
+      'error',
+      {
+        blankLine: 'always',
+        prev: 'directive',
+        next: '*',
+      },
+      {
+        blankLine: 'any',
+        prev: 'directive',
+        next: 'directive',
+      },
+      {
+        blankLine: 'always',
+        prev: 'multiline-block-like',
+        next: '*',
+      },
+      {
+        blankLine: 'always',
+        prev: '*',
+        next: 'multiline-block-like',
+      },
+    ],
+    // This prevents using bulleted/numbered lists in JSDoc blocks.
+    // See: <https://github.com/gajus/eslint-plugin-jsdoc/issues/541>
+    'jsdoc/check-indentation': 'off',
+    // It's common for scripts to access `process.env`
+    'node/no-process-env': 'off',
+    // It's common for scripts to exit explicitly
+    'node/no-process-exit': 'off',
+  },
 
   overrides: [
     {
@@ -10,15 +45,7 @@ module.exports = {
     },
 
     {
-      files: ['*.js'],
-      parserOptions: {
-        sourceType: 'script',
-      },
-      extends: ['@metamask/eslint-config-nodejs'],
-    },
-
-    {
-      files: ['*.test.ts', '*.test.js'],
+      files: ['*.test.ts'],
       extends: ['@metamask/eslint-config-jest'],
     },
   ],


### PR DESCRIPTION
* Assume that all JavaScript and TypeScript files are run in a Node
  context, and allow `process.env` to be accessed and `process.exit()`
  to be called freely.
* Tweak rules for blank lines. Currently we check that blank lines are
  inserted in between:

  * A directive prologue (like `use strict`) and anything else (except
    another directive prologue)
  * A multiline block-like statement (e.g. `if`, `while`, IIFEs, etc.)
    and a multiline expressions (e.g. multiline function calls)
  * A multiline block-like statement (e.g. `if`, `while`, IIFEs, etc.)
    and another multiline block-like statement
  * A multiline expression and a multiline block-like statement
  * A multiline expression and another multiline expression

  The issue is that enforcing line breaks in between multiline function
  or method calls makes organizing big integration tests more difficult.
  At the same time, multiline `if` statements more often than not
  involve some kind of complexity that would be unreadable smooshed up
  against some other code, so this commit also enforces empty line
  breaks around any kind of such statement.