### PR TITLE
Use Babel for Jest coverage provider

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -33,7 +33,7 @@ module.exports = {
   // ],
 
   // Indicates which provider should be used to instrument code for coverage
-  coverageProvider: 'v8',
+  coverageProvider: 'babel',
 
   // A list of reporter names that Jest uses when writing coverage reports
   coverageReporters: ['html', 'json-summary', 'text'],


### PR DESCRIPTION
v8 isn't quite reliable when using Node 14 for development (it has too
many false negatives). We can consider changing this back if/when we
switch to Node 16 or later, but for now we will stick to Babel.