### PR TITLE
Update release spec to only list changed packages

### DIFF
--- a/src/fs.ts
+++ b/src/fs.ts
@@ -6,6 +6,12 @@ import {
 import { wrapError, isErrorWithCode } from './misc-utils';
 
 /**
+ * Represents a writeable stream, such as that represented by `process.stdout`
+ * or `process.stderr`, or a fake one provided in tests.
+ */
+export type WriteStreamLike = Pick<fs.WriteStream, 'write'>;
+
+/**
  * Reads the file at the given path, assuming its content is encoded as UTF-8.
  *
  * @param filePath - The path to the file.

--- a/src/initial-parameters.ts
+++ b/src/initial-parameters.ts
@@ -1,6 +1,7 @@
 import os from 'os';
 import path from 'path';
 import { readCommandLineArguments } from './command-line-arguments';
+import { WriteStreamLike } from './fs';
 import { readProject, Project } from './project';
 
 interface InitialParameters {
@@ -13,18 +14,25 @@ interface InitialParameters {
  * Reads the inputs given to this tool via `process.argv` and uses them to
  * gather information about the project the tool can use to run.
  *
- * @param argv - The arguments to this executable.
- * @param cwd - The directory in which this executable was run.
+ * @param args - The arguments to this function.
+ * @param args.argv - The arguments to this executable.
+ * @param args.cwd - The directory in which this executable was run.
+ * @param args.stderr - A stream that can be used to write to standard error.
  * @returns The initial parameters.
  */
-export async function determineInitialParameters(
-  argv: string[],
-  cwd: string,
-): Promise<InitialParameters> {
+export async function determineInitialParameters({
+  argv,
+  cwd,
+  stderr,
+}: {
+  argv: string[];
+  cwd: string;
+  stderr: WriteStreamLike;
+}): Promise<InitialParameters> {
   const inputs = await readCommandLineArguments(argv);
 
   const projectDirectoryPath = path.resolve(cwd, inputs.projectDirectory);
-  const project = await readProject(projectDirectoryPath);
+  const project = await readProject(projectDirectoryPath, { stderr });
   const tempDirectoryPath =
     inputs.tempDirectory === undefined
       ? path.join(

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ export async function main({
   stderr: Pick<WriteStream, 'write'>;
 }) {
   const { project, tempDirectoryPath, reset } =
-    await determineInitialParameters(argv, cwd);
+    await determineInitialParameters({ argv, cwd, stderr });
 
   if (project.isMonorepo) {
     stdout.write(

--- a/src/misc-utils.test.ts
+++ b/src/misc-utils.test.ts
@@ -6,8 +6,10 @@ import {
   isErrorWithStack,
   wrapError,
   resolveExecutable,
-  getStdoutFromCommand,
   runCommand,
+  getStdoutFromCommand,
+  getLinesFromCommand,
+  placeInSpecificOrder,
 } from './misc-utils';
 
 jest.mock('which');
@@ -135,6 +137,24 @@ describe('misc-utils', () => {
     });
   });
 
+  describe('runCommand', () => {
+    it('runs the command, discarding its output', async () => {
+      const execaSpy = jest
+        .spyOn(execaModule, 'default')
+        // Typecast: It's difficult to provide a full return value for execa
+        .mockResolvedValue({ stdout: '   some output  ' } as any);
+
+      const result = await runCommand('some command', ['arg1', 'arg2'], {
+        all: true,
+      });
+
+      expect(execaSpy).toHaveBeenCalledWith('some command', ['arg1', 'arg2'], {
+        all: true,
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe('getStdoutFromCommand', () => {
     it('executes the given command and returns a version of the standard out from the command with whitespace trimmed', async () => {
       const execaSpy = jest
@@ -155,21 +175,75 @@ describe('misc-utils', () => {
     });
   });
 
-  describe('runCommand', () => {
-    it('runs the command, discarding its output', async () => {
+  describe('getLinesFromCommand', () => {
+    it('executes the given command and returns the standard out from the command split into lines', async () => {
       const execaSpy = jest
         .spyOn(execaModule, 'default')
         // Typecast: It's difficult to provide a full return value for execa
-        .mockResolvedValue({ stdout: '   some output  ' } as any);
+        .mockResolvedValue({ stdout: 'line 1\nline 2\nline 3' } as any);
 
-      const result = await runCommand('some command', ['arg1', 'arg2'], {
-        all: true,
-      });
+      const lines = await getLinesFromCommand(
+        'some command',
+        ['arg1', 'arg2'],
+        { all: true },
+      );
 
       expect(execaSpy).toHaveBeenCalledWith('some command', ['arg1', 'arg2'], {
         all: true,
       });
-      expect(result).toBeUndefined();
+      expect(lines).toStrictEqual(['line 1', 'line 2', 'line 3']);
+    });
+
+    it('does not strip leading and trailing whitespace from the output, but does remove empty lines', async () => {
+      const execaSpy = jest
+        .spyOn(execaModule, 'default')
+        // Typecast: It's difficult to provide a full return value for execa
+        .mockResolvedValue({
+          stdout: '  line 1\nline 2\n\n   line 3   \n',
+        } as any);
+
+      const lines = await getLinesFromCommand(
+        'some command',
+        ['arg1', 'arg2'],
+        { all: true },
+      );
+
+      expect(execaSpy).toHaveBeenCalledWith('some command', ['arg1', 'arg2'], {
+        all: true,
+      });
+      expect(lines).toStrictEqual(['  line 1', 'line 2', '   line 3   ']);
+    });
+  });
+
+  describe('placeInSpecificOrder', () => {
+    it('returns the first set of strings if the second set of strings is the same', () => {
+      expect(
+        placeInSpecificOrder(['foo', 'bar', 'baz'], ['foo', 'bar', 'baz']),
+      ).toStrictEqual(['foo', 'bar', 'baz']);
+    });
+
+    it('returns the first set of strings if the second set of strings is completely different', () => {
+      expect(
+        placeInSpecificOrder(['foo', 'bar', 'baz'], ['qux', 'blargh']),
+      ).toStrictEqual(['foo', 'bar', 'baz']);
+    });
+
+    it('returns the second set of strings if both sets of strings exactly have the same elements (just in a different order)', () => {
+      expect(
+        placeInSpecificOrder(
+          ['foo', 'qux', 'bar', 'baz'],
+          ['baz', 'foo', 'bar', 'qux'],
+        ),
+      ).toStrictEqual(['baz', 'foo', 'bar', 'qux']);
+    });
+
+    it('returns the first set of strings with the items common to both sets rearranged according to the second set, placing those unique to the first set last', () => {
+      expect(
+        placeInSpecificOrder(
+          ['foo', 'zing', 'qux', 'bar', 'baz', 'zam'],
+          ['baz', 'foo', 'bar', 'bam', 'qux', 'zox'],
+        ),
+      ).toStrictEqual(['baz', 'foo', 'bar', 'qux', 'zing', 'zam']);
     });
   });
 });

--- a/src/misc-utils.test.ts
+++ b/src/misc-utils.test.ts
@@ -214,36 +214,4 @@ describe('misc-utils', () => {
       expect(lines).toStrictEqual(['  line 1', 'line 2', '   line 3   ']);
     });
   });
-
-  describe('placeInSpecificOrder', () => {
-    it('returns the first set of strings if the second set of strings is the same', () => {
-      expect(
-        placeInSpecificOrder(['foo', 'bar', 'baz'], ['foo', 'bar', 'baz']),
-      ).toStrictEqual(['foo', 'bar', 'baz']);
-    });
-
-    it('returns the first set of strings if the second set of strings is completely different', () => {
-      expect(
-        placeInSpecificOrder(['foo', 'bar', 'baz'], ['qux', 'blargh']),
-      ).toStrictEqual(['foo', 'bar', 'baz']);
-    });
-
-    it('returns the second set of strings if both sets of strings exactly have the same elements (just in a different order)', () => {
-      expect(
-        placeInSpecificOrder(
-          ['foo', 'qux', 'bar', 'baz'],
-          ['baz', 'foo', 'bar', 'qux'],
-        ),
-      ).toStrictEqual(['baz', 'foo', 'bar', 'qux']);
-    });
-
-    it('returns the first set of strings with the items common to both sets rearranged according to the second set, placing those unique to the first set last', () => {
-      expect(
-        placeInSpecificOrder(
-          ['foo', 'zing', 'qux', 'bar', 'baz', 'zam'],
-          ['baz', 'foo', 'bar', 'bam', 'qux', 'zox'],
-        ),
-      ).toStrictEqual(['baz', 'foo', 'bar', 'qux', 'zing', 'zam']);
-    });
-  });
 });

--- a/src/misc-utils.test.ts
+++ b/src/misc-utils.test.ts
@@ -9,7 +9,6 @@ import {
   runCommand,
   getStdoutFromCommand,
   getLinesFromCommand,
-  placeInSpecificOrder,
 } from './misc-utils';
 
 jest.mock('which');

--- a/src/misc-utils.ts
+++ b/src/misc-utils.ts
@@ -119,6 +119,23 @@ export async function resolveExecutable(
 }
 
 /**
+ * Runs a command, discarding its output.
+ *
+ * @param command - The command to execute.
+ * @param args - The positional arguments to the command.
+ * @param options - The options to `execa`.
+ * @throws An `execa` error object if the command fails in some way.
+ * @see `execa`.
+ */
+export async function runCommand(
+  command: string,
+  args?: readonly string[] | undefined,
+  options?: execa.Options<string> | undefined,
+): Promise<void> {
+  await execa(command, args, options);
+}
+
+/**
  * Runs a command, retrieving the standard output with leading and trailing
  * whitespace removed.
  *
@@ -138,18 +155,46 @@ export async function getStdoutFromCommand(
 }
 
 /**
- * Runs a command, discarding its output.
+ * Runs a Git command, splitting up the immediate output into lines.
  *
  * @param command - The command to execute.
  * @param args - The positional arguments to the command.
  * @param options - The options to `execa`.
+ * @returns The standard output of the command.
  * @throws An `execa` error object if the command fails in some way.
  * @see `execa`.
  */
-export async function runCommand(
+export async function getLinesFromCommand(
   command: string,
   args?: readonly string[] | undefined,
   options?: execa.Options<string> | undefined,
-): Promise<void> {
-  await execa(command, args, options);
+): Promise<string[]> {
+  const { stdout } = await execa(command, args, options);
+  return stdout.split('\n').filter((value) => value !== '');
+}
+
+/**
+ * Reorders the given set of strings according to the sort order.
+ *
+ * @param unsortedStrings - A set of strings that need to be sorted.
+ * @param sortedStrings - A set of strings that designate the order in which
+ * the first set of strings should be placed.
+ * @returns A sorted version of `unsortedStrings`.
+ */
+export function placeInSpecificOrder(
+  unsortedStrings: string[],
+  sortedStrings: string[],
+): string[] {
+  const unsortedStringsCopy = unsortedStrings.slice();
+  const newSortedStrings: string[] = [];
+  sortedStrings.forEach((string) => {
+    const index = unsortedStringsCopy.indexOf(string);
+
+    if (index !== -1) {
+      unsortedStringsCopy.splice(index, 1);
+      newSortedStrings.push(string);
+    }
+  });
+  newSortedStrings.push(...unsortedStringsCopy);
+  return newSortedStrings;
 }

--- a/src/misc-utils.ts
+++ b/src/misc-utils.ts
@@ -172,29 +172,3 @@ export async function getLinesFromCommand(
   const { stdout } = await execa(command, args, options);
   return stdout.split('\n').filter((value) => value !== '');
 }
-
-/**
- * Reorders the given set of strings according to the sort order.
- *
- * @param unsortedStrings - A set of strings that need to be sorted.
- * @param sortedStrings - A set of strings that designate the order in which
- * the first set of strings should be placed.
- * @returns A sorted version of `unsortedStrings`.
- */
-export function placeInSpecificOrder(
-  unsortedStrings: string[],
-  sortedStrings: string[],
-): string[] {
-  const unsortedStringsCopy = unsortedStrings.slice();
-  const newSortedStrings: string[] = [];
-  sortedStrings.forEach((string) => {
-    const index = unsortedStringsCopy.indexOf(string);
-
-    if (index !== -1) {
-      unsortedStringsCopy.splice(index, 1);
-      newSortedStrings.push(string);
-    }
-  });
-  newSortedStrings.push(...unsortedStringsCopy);
-  return newSortedStrings;
-}

--- a/src/package.test.ts
+++ b/src/package.test.ts
@@ -67,6 +67,33 @@ describe('package', () => {
       });
     });
 
+    it('throws if a tag matching the current version does not exist', async () => {
+      jest
+        .spyOn(packageManifestModule, 'readPackageManifest')
+        .mockResolvedValue({
+          unvalidated: {},
+          validated: buildMockManifest({
+            name: 'some-package',
+            version: new SemVer('1.0.0'),
+          }),
+        });
+      when(jest.spyOn(repoModule, 'hasChangesInDirectorySinceGitTag'))
+        .calledWith('/path/to/project', '/path/to/package', 'v1.0.0')
+        .mockResolvedValue(true);
+
+      const promiseForPkg = readMonorepoRootPackage({
+        packageDirectoryPath: '/path/to/package',
+        projectDirectoryPath: '/path/to/project',
+        projectTagNames: ['some-tag'],
+      });
+
+      await expect(promiseForPkg).rejects.toThrow(
+        new Error(
+          'The package some-package has no Git tag for its current version 1.0.0 (expected "v1.0.0"), so this tool is unable to determine whether it should be included in this release. You will need to create a tag for this package in order to proceed.',
+        ),
+      );
+    });
+
     it("returns the fact that the package has been changed since its latest release, if a tag matching the current version exists and changes have been made to the package's directory since the tag", async () => {
       jest
         .spyOn(packageManifestModule, 'readPackageManifest')
@@ -198,6 +225,7 @@ describe('package', () => {
         packageDirectoryPath: '/path/to/package',
         projectDirectoryPath: '/path/to/project',
         projectTagNames: [],
+        rootPackageName: 'root-package',
         rootPackageVersion: new SemVer('5.0.0'),
       });
 
@@ -222,6 +250,7 @@ describe('package', () => {
         packageDirectoryPath: '/path/to/package',
         projectDirectoryPath: '/path/to/project',
         projectTagNames: [],
+        rootPackageName: 'root-package',
         rootPackageVersion: new SemVer('5.0.0'),
       });
 
@@ -229,6 +258,34 @@ describe('package', () => {
         unvalidatedManifest,
         validatedManifest,
       });
+    });
+
+    it('throws if a tag matching the current version does not exist', async () => {
+      const unvalidatedManifest = {};
+      const validatedManifest = buildMockManifest({
+        name: 'workspace-package',
+        version: new SemVer('1.0.0'),
+      });
+      when(jest.spyOn(packageManifestModule, 'readPackageManifest'))
+        .calledWith('/path/to/package/package.json')
+        .mockResolvedValue({
+          unvalidated: unvalidatedManifest,
+          validated: validatedManifest,
+        });
+
+      const promiseForPkg = readMonorepoWorkspacePackage({
+        packageDirectoryPath: '/path/to/package',
+        projectDirectoryPath: '/path/to/project',
+        projectTagNames: ['some-tag'],
+        rootPackageName: 'root-package',
+        rootPackageVersion: new SemVer('5.0.0'),
+      });
+
+      await expect(promiseForPkg).rejects.toThrow(
+        new Error(
+          'The workspace package workspace-package has no Git tag for its current version 1.0.0 (expected "workspace-package@1.0.0"), and the root package root-package has no Git tag for its current version 5.0.0 (expected "v5.0.0"), so this tool is unable to determine whether the workspace package should be included in this release. You will need to create tags for both of these packages in order to proceed.',
+        ),
+      );
     });
 
     it("returns the fact that the package has been changed since its latest release, if a tag matching the package name + version exists and changes have been made to the package's directory since the tag", async () => {
@@ -253,6 +310,7 @@ describe('package', () => {
         packageDirectoryPath: '/path/to/package',
         projectDirectoryPath: '/path/to/project',
         projectTagNames: ['@scope/some-package@1.0.0'],
+        rootPackageName: 'root-package',
         rootPackageVersion: new SemVer('5.0.0'),
       });
 
@@ -283,6 +341,7 @@ describe('package', () => {
         packageDirectoryPath: '/path/to/package',
         projectDirectoryPath: '/path/to/project',
         projectTagNames: ['@scope/some-package@1.0.0'],
+        rootPackageName: 'root-package',
         rootPackageVersion: new SemVer('5.0.0'),
       });
 
@@ -308,6 +367,7 @@ describe('package', () => {
         packageDirectoryPath: '/path/to/package',
         projectDirectoryPath: '/path/to/project',
         projectTagNames: ['v5.0.0'],
+        rootPackageName: 'root-package',
         rootPackageVersion: new SemVer('5.0.0'),
       });
 
@@ -333,6 +393,7 @@ describe('package', () => {
         packageDirectoryPath: '/path/to/package',
         projectDirectoryPath: '/path/to/project',
         projectTagNames: ['v5.0.0'],
+        rootPackageName: 'root-package',
         rootPackageVersion: new SemVer('5.0.0'),
       });
 
@@ -355,6 +416,7 @@ describe('package', () => {
         packageDirectoryPath: '/path/to/package',
         projectDirectoryPath: '/path/to/project',
         projectTagNames: [],
+        rootPackageName: 'root-package',
         rootPackageVersion: new SemVer('5.0.0'),
       });
 

--- a/src/package.test.ts
+++ b/src/package.test.ts
@@ -354,35 +354,6 @@ describe('package', () => {
       });
     });
 
-    it("prints a warning if a tag matching 'v' + the root package version exists instead of the package name + version", async () => {
-      const stderr = new MockWritable();
-      jest
-        .spyOn(packageManifestModule, 'readPackageManifest')
-        .mockResolvedValue({
-          unvalidated: {},
-          validated: buildMockManifest({
-            name: 'workspace-package',
-            version: new SemVer('1.0.0'),
-          }),
-        });
-      when(jest.spyOn(repoModule, 'hasChangesInDirectorySinceGitTag'))
-        .calledWith('/path/to/project', '/path/to/package', 'v5.0.0')
-        .mockResolvedValue(false);
-
-      await readMonorepoWorkspacePackage({
-        packageDirectoryPath: '/path/to/package',
-        projectDirectoryPath: '/path/to/project',
-        projectTagNames: ['v5.0.0'],
-        rootPackageName: 'root-package',
-        rootPackageVersion: new SemVer('5.0.0'),
-        stderr,
-      });
-
-      expect(stderr.data()).toStrictEqual(
-        'WARNING: It appears that the package workspace-package is missing a Git tag for its current release 1.0.0 (expected: "1.0.0"). This tool can make do with the tag that exists for root package ("v5.0.0"), but you should create this tag as soon as possible.',
-      );
-    });
-
     it("flags the package as having been changed since its latest release if a tag matching neither the package name + version nor 'v' + the root package version exists", async () => {
       jest
         .spyOn(packageManifestModule, 'readPackageManifest')

--- a/src/package.ts
+++ b/src/package.ts
@@ -37,23 +37,6 @@ export interface Package {
 }
 
 /**
- * Creates a sentence by connecting the given clauses with the given connector.
- *
- * @param connector - The connector, such as "and" or "or".
- * @param clauses - The clauses.
- * @returns The full sentence.
- */
-function connectClausesWith(connector: string, clauses: string[]) {
-  if (clauses.length < 3) {
-    return clauses.join(` ${connector} `);
-  }
-
-  return [clauses.slice(0, -1).join(`, `), clauses[clauses.length - 1]].join(
-    `, ${connector}`,
-  );
-}
-
-/**
  * Generates possible Git tag names for the root package of a monorepo. The only
  * tag name in use at this time is "v" + the package version.
  *
@@ -120,10 +103,7 @@ export async function readMonorepoRootPackage({
         'The package %s has no Git tag for its current version %s (expected %s), so this tool is unable to determine whether it should be included in this release. You will need to create a tag for this package in order to proceed.',
         validatedManifest.name,
         validatedManifest.version,
-        connectClausesWith(
-          'or',
-          expectedReleaseTagNames.map((tagName) => `"${tagName}"`),
-        ),
+        expectedReleaseTagNames.map((tagName) => `"${tagName}"`).join(', '),
       ),
     );
   }
@@ -200,18 +180,14 @@ export async function readMonorepoWorkspacePackage({
         'The workspace package %s has no Git tag for its current version %s (expected %s), and the root package %s has no Git tag for its current version %s (expected %s), so this tool is unable to determine whether the workspace package should be included in this release. You will need to create tags for both of these packages in order to proceed.',
         validatedManifest.name,
         validatedManifest.version,
-        connectClausesWith(
-          'or',
-          expectedWorkspacePackageReleaseTagNames.map(
-            (tagName) => `"${tagName}"`,
-          ),
-        ),
+        expectedWorkspacePackageReleaseTagNames
+          .map((tagName) => `"${tagName}"`)
+          .join(', '),
         rootPackageName,
         rootPackageVersion,
-        connectClausesWith(
-          'or',
-          expectedRootPackageReleaseTagNames.map((tagName) => `"${tagName}"`),
-        ),
+        expectedRootPackageReleaseTagNames
+          .map((tagName) => `"${tagName}"`)
+          .join(', '),
       ),
     );
   }

--- a/src/package.ts
+++ b/src/package.ts
@@ -2,8 +2,8 @@ import fs, { WriteStream } from 'fs';
 import path from 'path';
 import { format } from 'util';
 import { updateChangelog } from '@metamask/auto-changelog';
+import { WriteStreamLike, readFile, writeFile, writeJsonFile } from './fs';
 import { isErrorWithCode } from './misc-utils';
-import { readFile, writeFile, writeJsonFile } from './fs';
 import {
   readPackageManifest,
   UnvalidatedPackageManifest,
@@ -37,18 +37,18 @@ export interface Package {
 }
 
 /**
- * Generates possible Git tag names for the root package of a monorepo. The only
- * tag name in use at this time is "v" + the package version.
+ * Generates the possible Git tag name for the root package of a monorepo. The
+ * only tag name in use at this time is "v" + the package version.
  *
  * @param packageVersion - The version of the package.
  * @returns An array of possible release tag names.
  */
-function generateMonorepoRootPackageReleaseTagNames(packageVersion: string) {
-  return [`v${packageVersion}`];
+function generateMonorepoRootPackageReleaseTagName(packageVersion: string) {
+  return `v${packageVersion}`;
 }
 
 /**
- * Generates possible Git tag names for the workspace package of a monorepo.
+ * Generates a possible Git tag name for the workspace package of a monorepo.
  * Accounts for changes to `action-publish-release`, which going forward will
  * generate tags for workspace packages in `PACKAGE_NAME@MAJOR.MINOR.PATCH`.
  *
@@ -56,11 +56,11 @@ function generateMonorepoRootPackageReleaseTagNames(packageVersion: string) {
  * @param packageVersion - The version of the package.
  * @returns An array of possible release tag names.
  */
-function generateMonorepoWorkspacePackageReleaseTagNames(
+function generateMonorepoWorkspacePackageReleaseTagName(
   packageName: string,
   packageVersion: string,
 ) {
-  return [`${packageName}@${packageVersion}`];
+  return `${packageName}@${packageVersion}`;
 }
 
 /**
@@ -85,36 +85,35 @@ export async function readMonorepoRootPackage({
   const changelogPath = path.join(packageDirectoryPath, CHANGELOG_FILE_NAME);
   const { unvalidated: unvalidatedManifest, validated: validatedManifest } =
     await readPackageManifest(manifestPath);
-  const expectedReleaseTagNames = generateMonorepoRootPackageReleaseTagNames(
-    validatedManifest.version.toString(),
-  );
-  const tagNameMatchingLatestRelease = expectedReleaseTagNames.find(
-    (tagName) => {
-      return projectTagNames.includes(tagName);
-    },
+  const expectedTagNameForLatestRelease =
+    generateMonorepoRootPackageReleaseTagName(
+      validatedManifest.version.toString(),
+    );
+  const matchingTagNameForLatestRelease = projectTagNames.find(
+    (tagName) => tagName === expectedTagNameForLatestRelease,
   );
 
   if (
     projectTagNames.length > 0 &&
-    tagNameMatchingLatestRelease === undefined
+    matchingTagNameForLatestRelease === undefined
   ) {
     throw new Error(
       format(
         'The package %s has no Git tag for its current version %s (expected %s), so this tool is unable to determine whether it should be included in this release. You will need to create a tag for this package in order to proceed.',
         validatedManifest.name,
         validatedManifest.version,
-        expectedReleaseTagNames.map((tagName) => `"${tagName}"`).join(', '),
+        `"${expectedTagNameForLatestRelease}"`,
       ),
     );
   }
 
   const hasChangesSinceLatestRelease =
-    tagNameMatchingLatestRelease === undefined
+    matchingTagNameForLatestRelease === undefined
       ? true
       : await hasChangesInDirectorySinceGitTag(
           projectDirectoryPath,
           packageDirectoryPath,
-          tagNameMatchingLatestRelease,
+          expectedTagNameForLatestRelease,
         );
 
   return {
@@ -138,6 +137,7 @@ export async function readMonorepoRootPackage({
  * monorepo to which this package belongs.
  * @param args.projectDirectoryPath - The path to the project directory.
  * @param args.projectTagNames - The tag names across the whole project.
+ * @param args.stderr - A stream that can be used to write to standard error.
  * @returns Information about the package.
  */
 export async function readMonorepoWorkspacePackage({
@@ -146,59 +146,77 @@ export async function readMonorepoWorkspacePackage({
   rootPackageVersion,
   projectDirectoryPath,
   projectTagNames,
+  stderr,
 }: {
   packageDirectoryPath: string;
   rootPackageName: string;
   rootPackageVersion: SemVer;
   projectDirectoryPath: string;
   projectTagNames: string[];
+  stderr: WriteStreamLike;
 }): Promise<Package> {
   const manifestPath = path.join(packageDirectoryPath, MANIFEST_FILE_NAME);
   const changelogPath = path.join(packageDirectoryPath, CHANGELOG_FILE_NAME);
   const { unvalidated: unvalidatedManifest, validated: validatedManifest } =
     await readPackageManifest(manifestPath);
-  const expectedWorkspacePackageReleaseTagNames =
-    generateMonorepoWorkspacePackageReleaseTagNames(
+  const expectedTagNameForWorkspacePackageLatestRelease =
+    generateMonorepoWorkspacePackageReleaseTagName(
       validatedManifest.name,
       validatedManifest.version.toString(),
     );
-  const expectedRootPackageReleaseTagNames =
-    generateMonorepoRootPackageReleaseTagNames(rootPackageVersion.toString());
-  const tagNameMatchingLatestRelease = [
-    ...expectedWorkspacePackageReleaseTagNames,
-    ...expectedRootPackageReleaseTagNames,
-  ].find((tagName) => {
-    return projectTagNames.includes(tagName);
-  });
+  const expectedTagNameForRootPackageLatestRelease =
+    generateMonorepoRootPackageReleaseTagName(rootPackageVersion.toString());
+  const matchingTagNameForWorkspacePackageLatestRelease = projectTagNames.find(
+    (tagName) => tagName === expectedTagNameForWorkspacePackageLatestRelease,
+  );
+  const matchingTagNameForRootPackageLatestRelease = projectTagNames.find(
+    (tagName) => tagName === expectedTagNameForRootPackageLatestRelease,
+  );
+  const matchingTagNameForLatestRelease =
+    matchingTagNameForWorkspacePackageLatestRelease ??
+    matchingTagNameForRootPackageLatestRelease;
 
   if (
     projectTagNames.length > 0 &&
-    tagNameMatchingLatestRelease === undefined
+    matchingTagNameForLatestRelease === undefined
   ) {
     throw new Error(
       format(
-        'The workspace package %s has no Git tag for its current version %s (expected %s), and the root package %s has no Git tag for its current version %s (expected %s), so this tool is unable to determine whether the workspace package should be included in this release. You will need to create tags for both of these packages in order to proceed.',
+        'The current release of workspace package %s, %s, has no corresponding Git tag %s, and the current release of root package %s, %s, has no tag %s. Hence, this tool is unable to know whether the workspace package changed and should be included in this release. You will need to create tags for both of these packages in order to proceed.',
         validatedManifest.name,
         validatedManifest.version,
-        expectedWorkspacePackageReleaseTagNames
-          .map((tagName) => `"${tagName}"`)
-          .join(', '),
+        `"${expectedTagNameForWorkspacePackageLatestRelease}"`,
         rootPackageName,
         rootPackageVersion,
-        expectedRootPackageReleaseTagNames
-          .map((tagName) => `"${tagName}"`)
-          .join(', '),
+        `"${expectedTagNameForRootPackageLatestRelease}"`,
+      ),
+    );
+  }
+
+  if (
+    matchingTagNameForWorkspacePackageLatestRelease === undefined &&
+    matchingTagNameForRootPackageLatestRelease !== undefined
+  ) {
+    stderr.write(
+      format(
+        'WARNING: Could not determine changes for workspace package %s version %s based on Git tag %s; using tag for root package %s version %s, %s, instead.\n',
+        validatedManifest.name,
+        validatedManifest.version,
+        `"${expectedTagNameForWorkspacePackageLatestRelease}"`,
+        rootPackageName,
+        rootPackageVersion,
+        `"${expectedTagNameForRootPackageLatestRelease}"`,
       ),
     );
   }
 
   const hasChangesSinceLatestRelease =
-    tagNameMatchingLatestRelease === undefined
+    matchingTagNameForLatestRelease === undefined
       ? true
       : await hasChangesInDirectorySinceGitTag(
           projectDirectoryPath,
           packageDirectoryPath,
-          tagNameMatchingLatestRelease,
+          matchingTagNameForLatestRelease,
         );
 
   return {

--- a/src/project.test.ts
+++ b/src/project.test.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { when } from 'jest-when';
 import { SemVer } from 'semver';
 import { withSandbox } from '../tests/helpers';
-import { buildMockPackage } from '../tests/unit/helpers';
+import { buildMockPackage, createNoopWriteStream } from '../tests/unit/helpers';
 import { readProject } from './project';
 import * as packageModule from './package';
 import * as repoModule from './repo';
@@ -43,6 +43,7 @@ describe('project', () => {
           }),
         };
         const projectTagNames = ['tag1', 'tag2', 'tag3'];
+        const stderr = createNoopWriteStream();
         when(jest.spyOn(repoModule, 'getRepositoryHttpsUrl'))
           .calledWith(projectDirectoryPath)
           .mockResolvedValue(projectRepositoryUrl);
@@ -67,6 +68,7 @@ describe('project', () => {
             rootPackageVersion,
             projectDirectoryPath,
             projectTagNames,
+            stderr,
           })
           .mockResolvedValue(workspacePackages.a)
           .calledWith({
@@ -80,6 +82,7 @@ describe('project', () => {
             rootPackageVersion,
             projectDirectoryPath,
             projectTagNames,
+            stderr,
           })
           .mockResolvedValue(workspacePackages.b);
         await fs.promises.mkdir(path.join(projectDirectoryPath, 'packages'));
@@ -93,7 +96,9 @@ describe('project', () => {
           path.join(projectDirectoryPath, 'packages', 'subpackages', 'b'),
         );
 
-        expect(await readProject(projectDirectoryPath)).toStrictEqual({
+        expect(
+          await readProject(projectDirectoryPath, { stderr }),
+        ).toStrictEqual({
           directoryPath: projectDirectoryPath,
           repositoryUrl: projectRepositoryUrl,
           rootPackage,

--- a/src/project.test.ts
+++ b/src/project.test.ts
@@ -17,13 +17,18 @@ describe('project', () => {
       await withSandbox(async (sandbox) => {
         const projectDirectoryPath = sandbox.directoryPath;
         const projectRepositoryUrl = 'https://github.com/some-org/some-repo';
+        const rootPackageName = 'root';
         const rootPackageVersion = new SemVer('4.38.0');
-        const rootPackage = buildMockPackage('root', rootPackageVersion, {
-          directoryPath: projectDirectoryPath,
-          validatedManifest: {
-            workspaces: ['packages/a', 'packages/subpackages/*'],
+        const rootPackage = buildMockPackage(
+          rootPackageName,
+          rootPackageVersion,
+          {
+            directoryPath: projectDirectoryPath,
+            validatedManifest: {
+              workspaces: ['packages/a', 'packages/subpackages/*'],
+            },
           },
-        });
+        );
         const workspacePackages = {
           a: buildMockPackage('a', {
             directoryPath: path.join(projectDirectoryPath, 'packages', 'a'),
@@ -58,6 +63,7 @@ describe('project', () => {
               'packages',
               'a',
             ),
+            rootPackageName,
             rootPackageVersion,
             projectDirectoryPath,
             projectTagNames,
@@ -70,6 +76,7 @@ describe('project', () => {
               'subpackages',
               'b',
             ),
+            rootPackageName,
             rootPackageVersion,
             projectDirectoryPath,
             projectTagNames,

--- a/src/project.ts
+++ b/src/project.ts
@@ -112,6 +112,7 @@ export async function readProject(
       workspaceDirectories.map(async (directory) => {
         return await readMonorepoWorkspacePackage({
           packageDirectoryPath: directory,
+          rootPackageName: rootPackage.validatedManifest.name,
           rootPackageVersion: rootPackage.validatedManifest.version,
           projectDirectoryPath,
           projectTagNames: tagNames,

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,5 +1,6 @@
 import util from 'util';
 import glob from 'glob';
+import { WriteStreamLike } from './fs';
 import {
   Package,
   readMonorepoRootPackage,
@@ -73,6 +74,8 @@ function examineReleaseVersion(packageVersion: SemVer): ReleaseVersion {
  * packages within workspaces specified via the root `package.json`.
  *
  * @param projectDirectoryPath - The path to the project.
+ * @param args - Additional arguments.
+ * @param args.stderr - A stream that can be used to write to standard error.
  * @returns An object that represents information about the project.
  * @throws if the project does not contain a root `package.json` (polyrepo and
  * monorepo) or if any of the workspaces specified in the root `package.json` do
@@ -80,6 +83,7 @@ function examineReleaseVersion(packageVersion: SemVer): ReleaseVersion {
  */
 export async function readProject(
   projectDirectoryPath: string,
+  { stderr }: { stderr: WriteStreamLike },
 ): Promise<Project> {
   const repositoryUrl = await getRepositoryHttpsUrl(projectDirectoryPath);
   const tagNames = await getTagNames(projectDirectoryPath);
@@ -114,6 +118,7 @@ export async function readProject(
           rootPackageVersion: rootPackage.validatedManifest.version,
           projectDirectoryPath,
           projectTagNames: tagNames,
+          stderr,
         });
       }),
     )

--- a/src/project.ts
+++ b/src/project.ts
@@ -69,10 +69,8 @@ function examineReleaseVersion(packageVersion: SemVer): ReleaseVersion {
 }
 
 /**
- * Collects information about a project. For a polyrepo package, this
- * information will only cover the project's `package.json` file; for a
- * monorepo, it will cover `package.json` files for any workspaces that the
- * monorepo defines.
+ * Collects information about a monorepo — its root package as well as any
+ * packages within workspaces specified via the root `package.json`.
  *
  * @param projectDirectoryPath - The path to the project.
  * @returns An object that represents information about the project.

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,8 +1,12 @@
 import util from 'util';
 import glob from 'glob';
-import { Package, readPackage } from './package';
+import {
+  Package,
+  readMonorepoRootPackage,
+  readMonorepoWorkspacePackage,
+} from './package';
 import { PackageManifestFieldNames } from './package-manifest';
-import { getRepositoryHttpsUrl } from './repo';
+import { getRepositoryHttpsUrl, getTagNames } from './repo';
 import { SemVer } from './semver';
 
 /**
@@ -65,9 +69,10 @@ function examineReleaseVersion(packageVersion: SemVer): ReleaseVersion {
 }
 
 /**
- * Collects information about a project. For a polyrepo, this information will
- * only cover the project's `package.json` file; for a monorepo, it will cover
- * `package.json` files for any workspaces that the monorepo defines.
+ * Collects information about a project. For a polyrepo package, this
+ * information will only cover the project's `package.json` file; for a
+ * monorepo, it will cover `package.json` files for any workspaces that the
+ * monorepo defines.
  *
  * @param projectDirectoryPath - The path to the project.
  * @returns An object that represents information about the project.
@@ -79,7 +84,12 @@ export async function readProject(
   projectDirectoryPath: string,
 ): Promise<Project> {
   const repositoryUrl = await getRepositoryHttpsUrl(projectDirectoryPath);
-  const rootPackage = await readPackage(projectDirectoryPath);
+  const tagNames = await getTagNames(projectDirectoryPath);
+  const rootPackage = await readMonorepoRootPackage({
+    packageDirectoryPath: projectDirectoryPath,
+    projectDirectoryPath,
+    projectTagNames: tagNames,
+  });
   const releaseVersion = examineReleaseVersion(
     rootPackage.validatedManifest.version,
   );
@@ -100,7 +110,12 @@ export async function readProject(
   const workspacePackages = (
     await Promise.all(
       workspaceDirectories.map(async (directory) => {
-        return await readPackage(directory);
+        return await readMonorepoWorkspacePackage({
+          packageDirectoryPath: directory,
+          rootPackageVersion: rootPackage.validatedManifest.version,
+          projectDirectoryPath,
+          projectTagNames: tagNames,
+        });
       }),
     )
   ).reduce((obj, pkg) => {

--- a/src/release-specification.ts
+++ b/src/release-specification.ts
@@ -79,7 +79,17 @@ export async function generateReleaseSpecificationTemplateForMonorepo({
 ${afterEditingInstructions}
   `.trim();
 
-  const packages = Object.values(workspacePackages).reduce((obj, pkg) => {
+  const changedWorkspacePackages = Object.values(workspacePackages).filter(
+    (pkg) => pkg.hasChangesSinceLatestRelease,
+  );
+
+  if (changedWorkspacePackages.length === 0) {
+    throw new Error(
+      'Could not generate release specification: There are no packages that have changed since their latest release.',
+    );
+  }
+
+  const packages = changedWorkspacePackages.reduce((obj, pkg) => {
     return { ...obj, [pkg.validatedManifest.name]: null };
   }, {});
 

--- a/src/repo.test.ts
+++ b/src/repo.test.ts
@@ -1,29 +1,15 @@
 import { when } from 'jest-when';
 import {
-  getStdoutFromGitCommandWithin,
   getRepositoryHttpsUrl,
   captureChangesInReleaseBranch,
+  getTagNames,
+  hasChangesInDirectorySinceGitTag,
 } from './repo';
 import * as miscUtils from './misc-utils';
 
 jest.mock('./misc-utils');
 
-describe('git-utils', () => {
-  describe('getStdoutFromGitCommandWithin', () => {
-    it('calls getStdoutFromCommand with "git" as the command, passing the given args and using the given directory as the working directory', async () => {
-      when(jest.spyOn(miscUtils, 'getStdoutFromCommand'))
-        .calledWith('git', ['foo', 'bar'], { cwd: '/path/to/repo' })
-        .mockResolvedValue('the output');
-
-      const output = await getStdoutFromGitCommandWithin('/path/to/repo', [
-        'foo',
-        'bar',
-      ]);
-
-      expect(output).toStrictEqual('the output');
-    });
-  });
-
+describe('repo', () => {
   describe('getRepositoryHttpsUrl', () => {
     it('returns the URL of the "origin" remote of the given repo if it looks like a HTTPS public GitHub repo URL', async () => {
       const repositoryDirectoryPath = '/path/to/project';
@@ -115,6 +101,169 @@ describe('git-utils', () => {
         ['commit', '-m', 'Release 1.0.0'],
         { cwd: '/path/to/project' },
       );
+    });
+  });
+
+  describe('getTagNames', () => {
+    it('returns all of the tag names that match a known format, sorted from earliest created to latest created', async () => {
+      when(jest.spyOn(miscUtils, 'runCommand'))
+        .calledWith('git', ['fetch', '--tags'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue();
+      when(jest.spyOn(miscUtils, 'getLinesFromCommand'))
+        .calledWith('git', ['tag', '--merged'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue(['unsorted'])
+        .calledWith('git', ['rev-list', '--tags', '--date-order'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue(['sorted']);
+      when(jest.spyOn(miscUtils, 'placeInSpecificOrder'))
+        .calledWith(['unsorted'], ['sorted'])
+        .mockReturnValue(['tag1', 'tag2', 'tag3']);
+
+      expect(await getTagNames('/path/to/repo')).toStrictEqual([
+        'tag1',
+        'tag2',
+        'tag3',
+      ]);
+    });
+
+    it.only('returns an empty array if the repo has no tags as long as it was not cloned shallowly', async () => {
+      when(jest.spyOn(miscUtils, 'runCommand'))
+        .calledWith('git', ['fetch', '--tags'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue();
+      when(jest.spyOn(miscUtils, 'getLinesFromCommand'))
+        .calledWith('git', ['tag', '--merged'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue([])
+        .calledWith('git', ['rev-list', '--tags', '--date-order'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue([]);
+      when(jest.spyOn(miscUtils, 'getStdoutFromCommand'))
+        .calledWith('git', ['rev-parse', '--is-shallow-repository'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue('false');
+      when(jest.spyOn(miscUtils, 'placeInSpecificOrder'))
+        .calledWith([], [])
+        .mockReturnValue([]);
+
+      expect(await getTagNames('/path/to/repo')).toStrictEqual([]);
+    });
+
+    it('throws if the repo has no tags but it was cloned shallowly', async () => {
+      when(jest.spyOn(miscUtils, 'runCommand'))
+        .calledWith('git', ['fetch', '--tags'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue();
+      when(jest.spyOn(miscUtils, 'getLinesFromCommand'))
+        .calledWith('git', ['tag', '--merged'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue([])
+        .calledWith('git', ['rev-list', '--tags', '--date-order'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue([]);
+      when(jest.spyOn(miscUtils, 'getStdoutFromCommand'))
+        .calledWith('git', ['rev-parse', '--is-shallow-repository'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue('true');
+
+      await expect(getTagNames('/path/to/repo')).rejects.toThrow(
+        '"git tag" returned no tags. Increase your git fetch depth.',
+      );
+    });
+
+    it('throws if "git rev-parse --is-shallow-repository" returns neither "true" nor "false"', async () => {
+      when(jest.spyOn(miscUtils, 'runCommand'))
+        .calledWith('git', ['fetch', '--tags'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue();
+      when(jest.spyOn(miscUtils, 'getLinesFromCommand'))
+        .calledWith('git', ['tag', '--merged'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue([])
+        .calledWith('git', ['rev-list', '--tags', '--date-order'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue([]);
+      when(jest.spyOn(miscUtils, 'getStdoutFromCommand'))
+        .calledWith('git', ['rev-parse', '--is-shallow-repository'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue('something-else');
+
+      await expect(getTagNames('/path/to/repo')).rejects.toThrow(
+        '"git rev-parse --is-shallow-repository" returned unrecognized value: "something-else"',
+      );
+    });
+  });
+
+  describe('hasChangesInDirectorySinceGitTag', () => {
+    it('returns true if "git diff" includes any files within the given directory, for the first call', async () => {
+      when(jest.spyOn(miscUtils, 'getLinesFromCommand'))
+        .calledWith('git', ['diff', 'v1.0.0', 'HEAD', '--name-only'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue([
+          '/path/to/repo/file1',
+          '/path/to/repo/subdirectory/file1',
+        ]);
+
+      const hasChanges = await hasChangesInDirectorySinceGitTag(
+        '/path/to/repo',
+        '/path/to/repo/subdirectory',
+        'v1.0.0',
+      );
+
+      expect(hasChanges).toBe(true);
+    });
+
+    it('returns false if "git diff" does not include any files within the given directory, for the first call', async () => {
+      when(jest.spyOn(miscUtils, 'getLinesFromCommand'))
+        .calledWith('git', ['diff', 'v2.0.0', 'HEAD', '--name-only'], {
+          cwd: '/path/to/repo',
+        })
+        .mockResolvedValue(['/path/to/repo/file1', '/path/to/repo/file2']);
+
+      const hasChanges = await hasChangesInDirectorySinceGitTag(
+        '/path/to/repo',
+        '/path/to/repo/subdirectory',
+        'v2.0.0',
+      );
+
+      expect(hasChanges).toBe(false);
+    });
+
+    it('only runs "git diff" once when called more than once for the same tag name (even for a different subdirectory)', async () => {
+      const getLinesFromCommandSpy = jest
+        .spyOn(miscUtils, 'getLinesFromCommand')
+        .mockResolvedValue([]);
+
+      await hasChangesInDirectorySinceGitTag(
+        '/path/to/repo',
+        '/path/to/repo/subdirectory1',
+        'v3.0.0',
+      );
+      await hasChangesInDirectorySinceGitTag(
+        '/path/to/repo',
+        '/path/to/repo/subdirectory2',
+        'v3.0.0',
+      );
+
+      expect(getLinesFromCommandSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/repo.test.ts
+++ b/src/repo.test.ts
@@ -131,7 +131,7 @@ describe('repo', () => {
       ]);
     });
 
-    it.only('returns an empty array if the repo has no tags as long as it was not cloned shallowly', async () => {
+    it('returns an empty array if the repo has no tags as long as it was not cloned shallowly', async () => {
       when(jest.spyOn(miscUtils, 'runCommand'))
         .calledWith('git', ['fetch', '--tags'], {
           cwd: '/path/to/repo',

--- a/src/repo.test.ts
+++ b/src/repo.test.ts
@@ -106,23 +106,11 @@ describe('repo', () => {
 
   describe('getTagNames', () => {
     it('returns all of the tag names that match a known format, sorted from earliest created to latest created', async () => {
-      when(jest.spyOn(miscUtils, 'runCommand'))
-        .calledWith('git', ['fetch', '--tags'], {
-          cwd: '/path/to/repo',
-        })
-        .mockResolvedValue();
       when(jest.spyOn(miscUtils, 'getLinesFromCommand'))
-        .calledWith('git', ['tag', '--merged'], {
+        .calledWith('git', ['tag', '--merged', '--sort', 'version:refname'], {
           cwd: '/path/to/repo',
         })
-        .mockResolvedValue(['unsorted'])
-        .calledWith('git', ['rev-list', '--tags', '--date-order'], {
-          cwd: '/path/to/repo',
-        })
-        .mockResolvedValue(['sorted']);
-      when(jest.spyOn(miscUtils, 'placeInSpecificOrder'))
-        .calledWith(['unsorted'], ['sorted'])
-        .mockReturnValue(['tag1', 'tag2', 'tag3']);
+        .mockResolvedValue(['tag1', 'tag2', 'tag3']);
 
       expect(await getTagNames('/path/to/repo')).toStrictEqual([
         'tag1',
@@ -132,17 +120,8 @@ describe('repo', () => {
     });
 
     it('returns an empty array if the repo has no tags as long as it was not cloned shallowly', async () => {
-      when(jest.spyOn(miscUtils, 'runCommand'))
-        .calledWith('git', ['fetch', '--tags'], {
-          cwd: '/path/to/repo',
-        })
-        .mockResolvedValue();
       when(jest.spyOn(miscUtils, 'getLinesFromCommand'))
-        .calledWith('git', ['tag', '--merged'], {
-          cwd: '/path/to/repo',
-        })
-        .mockResolvedValue([])
-        .calledWith('git', ['rev-list', '--tags', '--date-order'], {
+        .calledWith('git', ['tag', '--merged', '--sort', 'version:refname'], {
           cwd: '/path/to/repo',
         })
         .mockResolvedValue([]);
@@ -151,25 +130,13 @@ describe('repo', () => {
           cwd: '/path/to/repo',
         })
         .mockResolvedValue('false');
-      when(jest.spyOn(miscUtils, 'placeInSpecificOrder'))
-        .calledWith([], [])
-        .mockReturnValue([]);
 
       expect(await getTagNames('/path/to/repo')).toStrictEqual([]);
     });
 
     it('throws if the repo has no tags but it was cloned shallowly', async () => {
-      when(jest.spyOn(miscUtils, 'runCommand'))
-        .calledWith('git', ['fetch', '--tags'], {
-          cwd: '/path/to/repo',
-        })
-        .mockResolvedValue();
       when(jest.spyOn(miscUtils, 'getLinesFromCommand'))
-        .calledWith('git', ['tag', '--merged'], {
-          cwd: '/path/to/repo',
-        })
-        .mockResolvedValue([])
-        .calledWith('git', ['rev-list', '--tags', '--date-order'], {
+        .calledWith('git', ['tag', '--merged', '--sort', 'version:refname'], {
           cwd: '/path/to/repo',
         })
         .mockResolvedValue([]);
@@ -185,17 +152,8 @@ describe('repo', () => {
     });
 
     it('throws if "git rev-parse --is-shallow-repository" returns neither "true" nor "false"', async () => {
-      when(jest.spyOn(miscUtils, 'runCommand'))
-        .calledWith('git', ['fetch', '--tags'], {
-          cwd: '/path/to/repo',
-        })
-        .mockResolvedValue();
       when(jest.spyOn(miscUtils, 'getLinesFromCommand'))
-        .calledWith('git', ['tag', '--merged'], {
-          cwd: '/path/to/repo',
-        })
-        .mockResolvedValue([])
-        .calledWith('git', ['rev-list', '--tags', '--date-order'], {
+        .calledWith('git', ['tag', '--merged', '--sort', 'version:refname'], {
           cwd: '/path/to/repo',
         })
         .mockResolvedValue([]);

--- a/src/repo.test.ts
+++ b/src/repo.test.ts
@@ -105,7 +105,7 @@ describe('repo', () => {
   });
 
   describe('getTagNames', () => {
-    it('returns all of the tag names that match a known format, sorted from earliest created to latest created', async () => {
+    it('returns all of the tag names that match a known format, sorted by ascending semantic version order', async () => {
       when(jest.spyOn(miscUtils, 'getLinesFromCommand'))
         .calledWith('git', ['tag', '--sort=version:refname', '--merged'], {
           cwd: '/path/to/repo',

--- a/src/repo.test.ts
+++ b/src/repo.test.ts
@@ -107,7 +107,7 @@ describe('repo', () => {
   describe('getTagNames', () => {
     it('returns all of the tag names that match a known format, sorted from earliest created to latest created', async () => {
       when(jest.spyOn(miscUtils, 'getLinesFromCommand'))
-        .calledWith('git', ['tag', '--merged', '--sort', 'version:refname'], {
+        .calledWith('git', ['tag', '--sort=version:refname', '--merged'], {
           cwd: '/path/to/repo',
         })
         .mockResolvedValue(['tag1', 'tag2', 'tag3']);
@@ -121,7 +121,7 @@ describe('repo', () => {
 
     it('returns an empty array if the repo has no tags as long as it was not cloned shallowly', async () => {
       when(jest.spyOn(miscUtils, 'getLinesFromCommand'))
-        .calledWith('git', ['tag', '--merged', '--sort', 'version:refname'], {
+        .calledWith('git', ['tag', '--sort=version:refname', '--merged'], {
           cwd: '/path/to/repo',
         })
         .mockResolvedValue([]);
@@ -136,7 +136,7 @@ describe('repo', () => {
 
     it('throws if the repo has no tags but it was cloned shallowly', async () => {
       when(jest.spyOn(miscUtils, 'getLinesFromCommand'))
-        .calledWith('git', ['tag', '--merged', '--sort', 'version:refname'], {
+        .calledWith('git', ['tag', '--sort=version:refname', '--merged'], {
           cwd: '/path/to/repo',
         })
         .mockResolvedValue([]);
@@ -153,7 +153,7 @@ describe('repo', () => {
 
     it('throws if "git rev-parse --is-shallow-repository" returns neither "true" nor "false"', async () => {
       when(jest.spyOn(miscUtils, 'getLinesFromCommand'))
-        .calledWith('git', ['tag', '--merged', '--sort', 'version:refname'], {
+        .calledWith('git', ['tag', '--sort=version:refname', '--merged'], {
           cwd: '/path/to/repo',
         })
         .mockResolvedValue([]);

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -211,11 +211,10 @@ export async function getTagNames(
     repositoryDirectoryPath,
     'tag',
     [
+      '--sort=version:refname',
       // The --merged flag ensures that we only get tags that are parents of or
       // equal to the current HEAD.
       '--merged',
-      '--sort',
-      'version:refname',
     ],
   );
 

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -194,8 +194,8 @@ export async function captureChangesInReleaseBranch(
 }
 
 /**
- * Retrieves the names of the tags in the given repo, sorted by earliest created
- * to latest created. As this fetches tags from the remote first, you are
+ * Retrieves the names of the tags in the given repo, sorted by ascending
+ * semantic version order. As this fetches tags from the remote first, you are
  * advised to only run this once.
  *
  * @param repositoryDirectoryPath - The path to the repository directory.

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -1,20 +1,29 @@
-import { getStdoutFromCommand } from './misc-utils';
+import {
+  runCommand,
+  getStdoutFromCommand,
+  getLinesFromCommand,
+  placeInSpecificOrder,
+} from './misc-utils';
+
+const CHANGED_FILE_PATHS_BY_TAG_NAME: Record<string, string[]> = {};
 
 /**
- * Runs a command within the given directory, obtaining the immediate output.
+ * Runs a Git command within the given repository, discarding its output.
  *
- * @param directoryPath - The path to the directory.
- * @param command - The command to execute.
- * @param args - The positional arguments to the command.
+ * @param repositoryDirectoryPath - The path to the repository directory.
+ * @param commandName - The name of the Git command (e.g., "commit").
+ * @param commandArgs - The arguments to the command.
  * @returns The standard output of the command.
  * @throws An execa error object if the command fails in some way.
  */
-async function getStdoutFromCommandWithin(
-  directoryPath: string,
-  command: string,
-  args?: readonly string[] | undefined,
-): Promise<string> {
-  return await getStdoutFromCommand(command, args, { cwd: directoryPath });
+async function runGitCommandWithin(
+  repositoryDirectoryPath: string,
+  commandName: string,
+  commandArgs: readonly string[],
+): Promise<void> {
+  await runCommand('git', [commandName, ...commandArgs], {
+    cwd: repositoryDirectoryPath,
+  });
 }
 
 /**
@@ -22,15 +31,93 @@ async function getStdoutFromCommandWithin(
  * output.
  *
  * @param repositoryDirectoryPath - The path to the repository directory.
- * @param args - The arguments to the command.
+ * @param commandName - The name of the Git command (e.g., "commit").
+ * @param commandArgs - The arguments to the command.
  * @returns The standard output of the command.
  * @throws An execa error object if the command fails in some way.
  */
-export async function getStdoutFromGitCommandWithin(
+async function getStdoutFromGitCommandWithin(
   repositoryDirectoryPath: string,
-  args: readonly string[],
-) {
-  return await getStdoutFromCommandWithin(repositoryDirectoryPath, 'git', args);
+  commandName: string,
+  commandArgs: readonly string[],
+): Promise<string> {
+  return await getStdoutFromCommand('git', [commandName, ...commandArgs], {
+    cwd: repositoryDirectoryPath,
+  });
+}
+
+/**
+ * Runs a Git command within the given repository, splitting up the immediate
+ * output into lines.
+ *
+ * @param repositoryDirectoryPath - The path to the repository directory.
+ * @param commandName - The name of the Git command (e.g., "commit").
+ * @param commandArgs - The arguments to the command.
+ * @returns A set of lines from the standard output of the command.
+ * @throws An execa error object if the command fails in some way.
+ */
+async function getLinesFromGitCommandWithin(
+  repositoryDirectoryPath: string,
+  commandName: string,
+  commandArgs: readonly string[],
+): Promise<string[]> {
+  return await getLinesFromCommand('git', [commandName, ...commandArgs], {
+    cwd: repositoryDirectoryPath,
+  });
+}
+
+/**
+ * Check whether the local repository has a complete git history.
+ * Implemented using `git rev-parse --is-shallow-repository`.
+ *
+ * @param repositoryDirectoryPath - The path to the repository directory.
+ * @returns Whether the local repository has a complete, as opposed to shallow,
+ * git history.
+ * @throws if `git rev-parse --is-shallow-repository` returns an unrecognized
+ * value.
+ */
+async function hasCompleteGitHistory(
+  repositoryDirectoryPath: string,
+): Promise<boolean> {
+  const isShallow = await getStdoutFromGitCommandWithin(
+    repositoryDirectoryPath,
+    'rev-parse',
+    ['--is-shallow-repository'],
+  );
+
+  // We invert the meaning of these strings because we want to know if the
+  // repository is NOT shallow.
+  if (isShallow === 'true') {
+    return false;
+  } else if (isShallow === 'false') {
+    return true;
+  }
+
+  throw new Error(
+    `"git rev-parse --is-shallow-repository" returned unrecognized value: ${JSON.stringify(
+      isShallow,
+    )}`,
+  );
+}
+
+/**
+ * Performs a diff in order to obtains a set of files that were changed in the
+ * given repository between a particular tag and HEAD.
+ *
+ * @param repositoryDirectoryPath - The path to the repository directory.
+ * @param tagName - The name of the tag to compare against HEAD.
+ * @returns An array of paths to files that have changes between the given tag
+ * and HEAD.
+ */
+async function getFilesChangedSince(
+  repositoryDirectoryPath: string,
+  tagName: string,
+): Promise<string[]> {
+  return await getLinesFromGitCommandWithin(repositoryDirectoryPath, 'diff', [
+    tagName,
+    'HEAD',
+    '--name-only',
+  ]);
 }
 
 /**
@@ -54,10 +141,10 @@ export async function getRepositoryHttpsUrl(
   const httpsPrefix = 'https://github.com';
   const sshPrefixRegex = /^git@github\.com:/u;
   const sshPostfixRegex = /\.git$/u;
-  const gitConfigUrl = await getStdoutFromCommandWithin(
+  const gitConfigUrl = await getStdoutFromGitCommandWithin(
     repositoryDirectoryPath,
-    'git',
-    ['config', '--get', 'remote.origin.url'],
+    'config',
+    ['--get', 'remote.origin.url'],
   );
 
   if (gitConfigUrl.startsWith(httpsPrefix)) {
@@ -88,23 +175,100 @@ export async function getRepositoryHttpsUrl(
  * of the new release).
  * 3. Switches to that branch.
  *
- * @param projectRepositoryPath - The path to the repository directory.
+ * @param repositoryDirectoryPath - The path to the repository directory.
  * @param args - The arguments.
  * @param args.releaseVersion - The release version.
  */
 export async function captureChangesInReleaseBranch(
-  projectRepositoryPath: string,
+  repositoryDirectoryPath: string,
   { releaseVersion }: { releaseVersion: string },
 ) {
-  await getStdoutFromGitCommandWithin(projectRepositoryPath, [
-    'checkout',
+  await getStdoutFromGitCommandWithin(repositoryDirectoryPath, 'checkout', [
     '-b',
     `release/${releaseVersion}`,
   ]);
-  await getStdoutFromGitCommandWithin(projectRepositoryPath, ['add', '-A']);
-  await getStdoutFromGitCommandWithin(projectRepositoryPath, [
-    'commit',
+  await getStdoutFromGitCommandWithin(repositoryDirectoryPath, 'add', ['-A']);
+  await getStdoutFromGitCommandWithin(repositoryDirectoryPath, 'commit', [
     '-m',
     `Release ${releaseVersion}`,
   ]);
+}
+
+/**
+ * Retrieves the names of the tags in the given repo, sorted by earliest created
+ * to latest created. As this fetches tags from the remote first, you are
+ * advised to only run this once.
+ *
+ * @param repositoryDirectoryPath - The path to the repository directory.
+ * @returns The names of the tags.
+ * @throws If no tags are found and the local git history is incomplete.
+ */
+export async function getTagNames(
+  repositoryDirectoryPath: string,
+): Promise<string[]> {
+  await runGitCommandWithin(repositoryDirectoryPath, 'fetch', ['--tags']);
+
+  // The --merged flag ensures that we only get tags that are parents of or
+  // equal to the current HEAD.
+  const unsortedMergedTagNames = await getLinesFromGitCommandWithin(
+    repositoryDirectoryPath,
+    'tag',
+    ['--merged'],
+  );
+  const sortedComprehensiveTagNames = await getLinesFromGitCommandWithin(
+    repositoryDirectoryPath,
+    'rev-list',
+    ['--tags', '--date-order'],
+  );
+
+  if (
+    unsortedMergedTagNames.length === 0 &&
+    sortedComprehensiveTagNames.length === 0 &&
+    !(await hasCompleteGitHistory(repositoryDirectoryPath))
+  ) {
+    throw new Error(
+      `"git tag" returned no tags. Increase your git fetch depth.`,
+    );
+  }
+
+  return placeInSpecificOrder(
+    unsortedMergedTagNames,
+    sortedComprehensiveTagNames,
+  );
+}
+
+/**
+ * Calculates whether there have been any commits since the given tag that
+ * include changes to any of the files within the given directory.
+ *
+ * @param repositoryDirectoryPath - The path to the repository directory.
+ * @param directoryPath - The path to a subdirectory within the repository.
+ * @param tagName - The name of a tag in the repository.
+ * @returns True or false, depending on the result.
+ */
+export async function hasChangesInDirectorySinceGitTag(
+  repositoryDirectoryPath: string,
+  directoryPath: string,
+  tagName: string,
+): Promise<boolean> {
+  let changedFilePaths: string[];
+
+  if (tagName in CHANGED_FILE_PATHS_BY_TAG_NAME) {
+    changedFilePaths = CHANGED_FILE_PATHS_BY_TAG_NAME[tagName];
+  } else {
+    changedFilePaths = await getFilesChangedSince(
+      repositoryDirectoryPath,
+      tagName,
+    );
+    // This function is the only thing that updates
+    // CHANGED_FILE_PATHS_BY_TAG_NAME, so there's no chance that it would get
+    // updated while the promise above is being resolved.
+    // TODO: Use mutex?
+    /* eslint-disable-next-line require-atomic-updates */
+    CHANGED_FILE_PATHS_BY_TAG_NAME[tagName] = changedFilePaths;
+  }
+
+  return changedFilePaths.some((filePath) => {
+    return filePath.startsWith(directoryPath);
+  });
 }

--- a/tests/unit/helpers.ts
+++ b/tests/unit/helpers.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import { SemVer } from 'semver';
 import { isPlainObject } from '@metamask/utils';
@@ -139,4 +140,14 @@ export function buildMockManifest(
     [PackageManifestFieldNames.Workspaces]: [],
     ...overrides,
   };
+}
+
+/**
+ * Creates a write stream that discards all messages sent to it. This is useful
+ * as a default value for functions that need to take a `stdout` or `stderr`.
+ *
+ * @returns The write stream.
+ */
+export function createNoopWriteStream(): fs.WriteStream {
+  return fs.createWriteStream('/dev/null');
 }

--- a/tests/unit/helpers.ts
+++ b/tests/unit/helpers.ts
@@ -21,7 +21,13 @@ type Unrequire<T, K extends keyof T> = Omit<T, K> & {
 };
 
 type MockPackageOverrides = Omit<
-  Unrequire<Package, 'directoryPath' | 'manifestPath' | 'changelogPath'>,
+  Unrequire<
+    Package,
+    | 'directoryPath'
+    | 'manifestPath'
+    | 'changelogPath'
+    | 'hasChangesSinceLatestRelease'
+  >,
   'unvalidatedManifest' | 'validatedManifest'
 > & {
   validatedManifest?: Omit<
@@ -98,6 +104,7 @@ export function buildMockPackage(
     directoryPath = `/path/to/packages/${name}`,
     manifestPath = path.join(directoryPath, 'package.json'),
     changelogPath = path.join(directoryPath, 'CHANGELOG.md'),
+    hasChangesSinceLatestRelease = false,
   } = overrides;
 
   return {
@@ -111,6 +118,7 @@ export function buildMockPackage(
     }),
     manifestPath,
     changelogPath,
+    hasChangesSinceLatestRelease,
   };
 }
 


### PR DESCRIPTION
This PR adds a new property to the Package object,
`hasChangesSinceLatestRelease`. This property is computed when a package
is read from a project by running a diff between the last-created Git
tag associated with that package and whatever the HEAD commit happens to
be, then checking to see whether any of the files changed belong to that
package. If they do, then `hasChangesSinceLatestRelease` is true,
otherwise it's false. This property is then used to filter the list of
packages that are placed within the release spec template when it is
generated.

There are a couple of things to consider here:

* "the last-created Git tag associated with that package" — how do we
know this? How do we map a package's version to a tag? We have to
account for tags that were created by `action-create-release-pr` in the
past as well as the tags that this tool will create in the future. We
also have to know what kind of package this is — whether it's the root
package of a monorepo or a workspace package — because the set of
possible tags will differ. These differences are documented in
`readMonorepoRootPackage` and `readMonorepoWorkspacePackage`.
* What happens if a repo has no tags? Then all of the packages in that
repo are considered to have changed, as they have yet to receive their
initial release, so they will all be included in the release spec
template.

---

Fixes #8.