### PR TITLE
Bump @metamask/utils to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@metamask/action-utils": "^0.0.2",
-    "@metamask/utils": "^2.0.0",
+    "@metamask/utils": "^2.1.0",
     "debug": "^4.3.4",
     "execa": "^5.0.0",
     "glob": "^8.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -871,7 +871,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^9.0.0
     "@metamask/eslint-config-nodejs": ^9.0.0
     "@metamask/eslint-config-typescript": ^9.0.1
-    "@metamask/utils": ^2.0.0
+    "@metamask/utils": ^2.1.0
     "@types/debug": ^4.1.7
     "@types/jest": ^28.1.4
     "@types/jest-when": ^3.5.2
@@ -961,12 +961,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@metamask/utils@npm:2.0.0"
+"@metamask/utils@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@metamask/utils@npm:2.1.0"
   dependencies:
     fast-deep-equal: ^3.1.3
-  checksum: 517afc6724e58aee889b9962fcedc0345cb264ed8232756cd16e2d47e22b5501af276986a3d84a9ab903075d20802bf38ff4f6a70c58a158666f18cb69ff458d
+  checksum: 50970fe28cbf98fbc34fb4f69d9bc90f5db94929c69ab532f57b48f42163ea77fb080ab31854efd984361c3e29e67831a78d94d1211ac3bcc6b9557769c73127
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Supercedes #26 (see there for release notes). This update has no impact on this tool but we might as well bump it.