### PR TITLE
Support backport releases

### DIFF
--- a/src/command-line-arguments.ts
+++ b/src/command-line-arguments.ts
@@ -5,6 +5,7 @@ export interface CommandLineArguments {
   projectDirectory: string;
   tempDirectory: string | undefined;
   reset: boolean;
+  backport: boolean;
 }
 
 /**
@@ -34,6 +35,12 @@ export async function readCommandLineArguments(
     .option('reset', {
       describe:
         'Removes any cached files from a previous run that may have been created.',
+      type: 'boolean',
+      default: false,
+    })
+    .option('backport', {
+      describe:
+        'Instructs the tool to bump the second part of the version rather than the first for a backport release.',
       type: 'boolean',
       default: false,
     })

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -17,7 +17,8 @@ describe('main', () => {
       .mockResolvedValue({
         project,
         tempDirectoryPath: '/path/to/temp/directory',
-        reset: false,
+        reset: true,
+        releaseType: 'backport',
       });
     const followMonorepoWorkflowSpy = jest
       .spyOn(monorepoWorkflowOperations, 'followMonorepoWorkflow')
@@ -33,7 +34,8 @@ describe('main', () => {
     expect(followMonorepoWorkflowSpy).toHaveBeenCalledWith({
       project,
       tempDirectoryPath: '/path/to/temp/directory',
-      firstRemovingExistingReleaseSpecification: false,
+      firstRemovingExistingReleaseSpecification: true,
+      releaseType: 'backport',
       stdout,
       stderr,
     });
@@ -49,6 +51,7 @@ describe('main', () => {
         project,
         tempDirectoryPath: '/path/to/temp/directory',
         reset: false,
+        releaseType: 'backport',
       });
     const followMonorepoWorkflowSpy = jest
       .spyOn(monorepoWorkflowOperations, 'followMonorepoWorkflow')

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ export async function main({
   stdout: Pick<WriteStream, 'write'>;
   stderr: Pick<WriteStream, 'write'>;
 }) {
-  const { project, tempDirectoryPath, reset } =
+  const { project, tempDirectoryPath, reset, releaseType } =
     await determineInitialParameters({ argv, cwd, stderr });
 
   if (project.isMonorepo) {
@@ -36,6 +36,7 @@ export async function main({
       project,
       tempDirectoryPath,
       firstRemovingExistingReleaseSpecification: reset,
+      releaseType,
       stdout,
       stderr,
     });

--- a/src/monorepo-workflow-operations.ts
+++ b/src/monorepo-workflow-operations.ts
@@ -7,6 +7,7 @@ import {
   writeFile,
 } from './fs';
 import { determineEditor } from './editor';
+import { ReleaseType } from './initial-parameters';
 import { Project } from './project';
 import { planRelease, executeReleasePlan } from './release-plan';
 import { captureChangesInReleaseBranch } from './repo';
@@ -35,27 +36,31 @@ import {
  * commit that includes the changes, then create a branch using the current date
  * as the name.
  *
- * @param options - The options.
- * @param options.project - Information about the project.
- * @param options.tempDirectoryPath - A directory in which to hold the generated
+ * @param args - The arguments to this function.
+ * @param args.project - Information about the project.
+ * @param args.tempDirectoryPath - A directory in which to hold the generated
  * release spec file.
- * @param options.firstRemovingExistingReleaseSpecification - Sometimes it's
+ * @param args.firstRemovingExistingReleaseSpecification - Sometimes it's
  * possible for a release specification that was created in a previous run to
  * stick around (due to an error). This will ensure that the file is removed
  * first.
- * @param options.stdout - A stream that can be used to write to standard out.
- * @param options.stderr - A stream that can be used to write to standard error.
+ * @param args.releaseType - The type of release ("ordinary" or "backport"),
+ * which affects how the version is bumped.
+ * @param args.stdout - A stream that can be used to write to standard out.
+ * @param args.stderr - A stream that can be used to write to standard error.
  */
 export async function followMonorepoWorkflow({
   project,
   tempDirectoryPath,
   firstRemovingExistingReleaseSpecification,
+  releaseType,
   stdout,
   stderr,
 }: {
   project: Project;
   tempDirectoryPath: string;
   firstRemovingExistingReleaseSpecification: boolean;
+  releaseType: ReleaseType;
   stdout: Pick<WriteStream, 'write'>;
   stderr: Pick<WriteStream, 'write'>;
 }) {
@@ -107,6 +112,7 @@ export async function followMonorepoWorkflow({
   const releasePlan = await planRelease({
     project,
     releaseSpecification,
+    releaseType,
   });
   await executeReleasePlan(project, releasePlan, stderr);
   await removeFile(releaseSpecificationPath);

--- a/src/release-plan.ts
+++ b/src/release-plan.ts
@@ -1,5 +1,6 @@
 import type { WriteStream } from 'fs';
 import { SemVer } from 'semver';
+import { ReleaseType } from './initial-parameters';
 import { debug } from './misc-utils';
 import { Package, updatePackage } from './package';
 import { Project } from './project';
@@ -54,16 +55,25 @@ export interface PackageReleasePlan {
  * packages and where they can found).
  * @param args.releaseSpecification - A parsed version of the release spec
  * entered by the user.
+ * @param args.releaseType - The type of release ("ordinary" or "backport"),
+ * which affects how the version is bumped.
  * @returns A promise for information about the new release.
  */
 export async function planRelease({
   project,
   releaseSpecification,
+  releaseType,
 }: {
   project: Project;
   releaseSpecification: ReleaseSpecification;
+  releaseType: ReleaseType;
 }): Promise<ReleasePlan> {
-  const newReleaseVersion = `${project.releaseVersion.ordinaryNumber + 1}.0.0`;
+  const newReleaseVersion =
+    releaseType === 'backport'
+      ? `${project.releaseVersion.ordinaryNumber}.${
+          project.releaseVersion.backportNumber + 1
+        }.0`
+      : `${project.releaseVersion.ordinaryNumber + 1}.0.0`;
 
   const rootReleasePlan: PackageReleasePlan = {
     package: project.rootPackage,

--- a/tests/functional/helpers/monorepo-environment.ts
+++ b/tests/functional/helpers/monorepo-environment.ts
@@ -73,6 +73,7 @@ export default class MonorepoEnvironment<
    * continuing.
    *
    * @param args - The arguments to this function.
+   * @param args.args - Additional arguments to pass to the command.
    * @param args.releaseSpecification - An object which specifies which packages
    * should be bumped, where keys are the *nicknames* of packages as specified
    * in the set of options passed to `withMonorepoProjectEnvironment`. Will be
@@ -80,8 +81,10 @@ export default class MonorepoEnvironment<
    * @returns The result of the command.
    */
   async runTool({
+    args: additionalArgs = [],
     releaseSpecification: releaseSpecificationWithPackageNicknames,
   }: {
+    args?: string[];
     releaseSpecification: ReleaseSpecification<WorkspacePackageNickname>;
   }): Promise<ExecaReturnValue<string>> {
     const releaseSpecificationPath = path.join(
@@ -122,22 +125,19 @@ cat "${releaseSpecificationPath}" > "$1"
     );
     await fs.promises.chmod(releaseSpecificationEditorPath, 0o777);
 
+    const args = [
+      '--transpileOnly',
+      TOOL_EXECUTABLE_PATH,
+      '--project-directory',
+      this.localRepo.getWorkingDirectoryPath(),
+      '--temp-directory',
+      path.join(this.localRepo.getWorkingDirectoryPath(), 'tmp'),
+      ...additionalArgs,
+    ];
     const env = {
       EDITOR: releaseSpecificationEditorPath,
     };
-
-    const result = await this.localRepo.runCommand(
-      TS_NODE_PATH,
-      [
-        '--transpileOnly',
-        TOOL_EXECUTABLE_PATH,
-        '--project-directory',
-        this.localRepo.getWorkingDirectoryPath(),
-        '--temp-directory',
-        path.join(this.localRepo.getWorkingDirectoryPath(), 'tmp'),
-      ],
-      { env },
-    );
+    const result = await this.localRepo.runCommand(TS_NODE_PATH, args, { env });
 
     debug(
       ['---- START OUTPUT -----', result.all, '---- END OUTPUT -----'].join(


### PR DESCRIPTION
Every so often we may want to copy a fix from the latest version of a package to a previously-released version. This type of release is called a backport.

Outside of any automation, when we want to apply a backport, we will switch to the Git tag that corresponds to the previous release, cut a new branch that corresponds to that particular version line (e.g. `1.x`), apply the fixes, push a pull request for those fixes, and merge them into that branch. When we want to *release* these changes, we will make another branch, bump versions and update changelogs, push that branch as a pull request, merge it in, and then finally publish NPM packages and create the GitHub release.

So we want to automate this workflow, but one question that comes to mind is, what version do we assign to such a release? Typically, when we issue a new release that *isn't* a backport, we will bump the first part of the version string (e.g. if the current version is "1.0.0", we will assign "2.0.0" as the new version string). Since backports are applied to previous releases, they are assigned a new version that is a modification of the version they are fixing. So when we name a backport release, we will take the base version and bump its *second* part (e.g. if the existing version is "1.0.0", the backport release will be called "1.1.0").

With that in mind, this commit adds a `--backport` option to the tool. When you specify this, it will assume that you are already on a version line branch (e.g. `1.x`) and that the current version of the primary package (the root package for a monorepo, the sole package for a polyrepo package) is the one that you want to fix. It will then use *this* version of the package (instead of the latest released version) to apply the changes. In the case of a monorepo, it will determine which workspace packages have changed since the Git tag that corresponds to the current version of the primary package (again, not the latest tag) and use this to populate the release spec. It will then bump the second part of the primary package version (as opposed to the first) and proceed as usual.

---

Fixes #32.