### PR TITLE
Fix hasChangesInDirectorySinceGitTag

### DIFF
--- a/src/repo.test.ts
+++ b/src/repo.test.ts
@@ -175,10 +175,7 @@ describe('repo', () => {
         .calledWith('git', ['diff', 'v1.0.0', 'HEAD', '--name-only'], {
           cwd: '/path/to/repo',
         })
-        .mockResolvedValue([
-          '/path/to/repo/file1',
-          '/path/to/repo/subdirectory/file1',
-        ]);
+        .mockResolvedValue(['file1', 'subdirectory/file1']);
 
       const hasChanges = await hasChangesInDirectorySinceGitTag(
         '/path/to/repo',
@@ -194,7 +191,7 @@ describe('repo', () => {
         .calledWith('git', ['diff', 'v2.0.0', 'HEAD', '--name-only'], {
           cwd: '/path/to/repo',
         })
-        .mockResolvedValue(['/path/to/repo/file1', '/path/to/repo/file2']);
+        .mockResolvedValue(['file1', 'file2']);
 
       const hasChanges = await hasChangesInDirectorySinceGitTag(
         '/path/to/repo',

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import {
   runCommand,
   getStdoutFromCommand,
@@ -112,11 +113,14 @@ async function getFilesChangedSince(
   repositoryDirectoryPath: string,
   tagName: string,
 ): Promise<string[]> {
-  return await getLinesFromGitCommandWithin(repositoryDirectoryPath, 'diff', [
-    tagName,
-    'HEAD',
-    '--name-only',
-  ]);
+  const partialFilePaths = await getLinesFromGitCommandWithin(
+    repositoryDirectoryPath,
+    'diff',
+    [tagName, 'HEAD', '--name-only'],
+  );
+  return partialFilePaths.map((partialFilePath) =>
+    path.join(repositoryDirectoryPath, partialFilePath),
+  );
 }
 
 /**


### PR DESCRIPTION
To determine whether a package needs a new release, we ask if there have been any new commits that contain changes to any of the files within that package. In other words, we run a `git diff` on the repo and look for any files that match that package.

The problem is that `git diff` returns partial file paths, that is, file paths which are relative to the repository directory, whereas the subdirectory path that `hasChangesInDirectorySinceGitTag` takes is an absolute path. So when we look for matching packages we always come up short. This confuses the tool because it doesn't think there are any new changes to release.