### PR TITLE
Fix lint error when no build is present

### DIFF
--- a/bin/create-release-branch.js
+++ b/bin/create-release-branch.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
-/* eslint-disable-next-line import/no-unassigned-import */
+/* eslint-disable-next-line import/no-unassigned-import,import/no-unresolved */
 require('../dist/cli');


### PR DESCRIPTION
The `create-release-branch.js` script targets the build output, so it fails the `import/no-unresolved` ESLint rule unless a build is present. This has been resolved with an ignore comment.