### PR TITLE
Update changelogs correctly for monorepo packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",
-    "@metamask/auto-changelog": "^2.3.0",
+    "@metamask/auto-changelog": "^3.0.0",
     "@metamask/eslint-config": "^10.0.0",
     "@metamask/eslint-config-jest": "^10.0.0",
     "@metamask/eslint-config-nodejs": "^10.0.0",

--- a/src/functional.test.ts
+++ b/src/functional.test.ts
@@ -304,8 +304,8 @@ describe('create-release-branch (functional)', () => {
               - Update "a"
               - Initial commit
 
-              [Unreleased]: https://github.com/example-org/example-repo/compare/v2.0.0...HEAD
-              [2.0.0]: https://github.com/example-org/example-repo/releases/tag/v2.0.0
+              [Unreleased]: https://github.com/example-org/example-repo/compare/@scope/a@2.0.0...HEAD
+              [2.0.0]: https://github.com/example-org/example-repo/releases/tag/@scope/a@2.0.0
             `),
           );
           expect(
@@ -318,8 +318,8 @@ describe('create-release-branch (functional)', () => {
               ### Uncategorized
               - Initial commit
 
-              [Unreleased]: https://github.com/example-org/example-repo/compare/v2.0.0...HEAD
-              [2.0.0]: https://github.com/example-org/example-repo/releases/tag/v2.0.0
+              [Unreleased]: https://github.com/example-org/example-repo/compare/@scope/b@2.0.0...HEAD
+              [2.0.0]: https://github.com/example-org/example-repo/releases/tag/@scope/b@2.0.0
             `),
           );
         },
@@ -652,8 +652,8 @@ The release spec file has been retained for you to edit again and make the neces
               - Update "a"
               - Initial commit
 
-              [Unreleased]: https://github.com/example-org/example-repo/compare/v2.0.0...HEAD
-              [2.0.0]: https://github.com/example-org/example-repo/releases/tag/v2.0.0
+              [Unreleased]: https://github.com/example-org/example-repo/compare/@scope/a@2.0.0...HEAD
+              [2.0.0]: https://github.com/example-org/example-repo/releases/tag/@scope/a@2.0.0
             `),
           );
           expect(

--- a/src/functional.test.ts
+++ b/src/functional.test.ts
@@ -326,6 +326,225 @@ describe('create-release-branch (functional)', () => {
       );
     });
 
+    it('updates package changelogs with package changes since the last package release', async () => {
+      await withMonorepoProjectEnvironment(
+        {
+          packages: {
+            $root$: {
+              name: '@scope/monorepo',
+              version: '1.0.0',
+              directoryPath: '.',
+            },
+            a: {
+              name: '@scope/a',
+              version: '1.0.0',
+              directoryPath: 'packages/a',
+            },
+            b: {
+              name: '@scope/b',
+              version: '1.0.0',
+              directoryPath: 'packages/b',
+            },
+          },
+          workspaces: {
+            '.': ['packages/*'],
+          },
+          createInitialCommit: false,
+        },
+        async (environment) => {
+          // Create an initial commit
+          await environment.writeFileWithinPackage(
+            'a',
+            'CHANGELOG.md',
+            buildChangelog(`
+            ## [Unreleased]
+
+            ## [1.0.0]
+            ### Added
+            - Initial release
+
+            [Unreleased]: https://github.com/example-org/example-repo/compare/@scope/a@1.0.0...HEAD
+            [1.0.0]: https://github.com/example-org/example-repo/releases/tag/@scope/a@1.0.0
+            `),
+          );
+          await environment.writeFileWithinPackage(
+            'b',
+            'CHANGELOG.md',
+            buildChangelog(`
+            ## [Unreleased]
+
+            ## [1.0.0]
+            ### Added
+            - Initial release
+
+            [Unreleased]: https://github.com/example-org/example-repo/compare/@scope/b@1.0.0...HEAD
+            [1.0.0]: https://github.com/example-org/example-repo/releases/tag/@scope/b@1.0.0
+            `),
+          );
+          await environment.createCommit('Initial commit');
+          await environment.runCommand('git', ['tag', '@scope/a@1.0.0']);
+          await environment.runCommand('git', ['tag', '@scope/b@1.0.0']);
+          await environment.runCommand('git', ['tag', 'v1.0.0']);
+
+          // Create another commit that only changes "a"
+          await environment.writeFileWithinPackage(
+            'a',
+            'dummy.txt',
+            'Some content',
+          );
+          await environment.createCommit('Update "a"');
+
+          // Run the tool
+          await environment.runTool({
+            releaseSpecification: {
+              packages: {
+                a: 'major',
+              },
+            },
+          });
+
+          // Only "a" should be updated
+          expect(
+            await environment.readFileWithinPackage('a', 'CHANGELOG.md'),
+          ).toStrictEqual(
+            buildChangelog(`
+              ## [Unreleased]
+
+              ## [2.0.0]
+              ### Uncategorized
+              - Update "a"
+
+              ## [1.0.0]
+              ### Added
+              - Initial release
+
+              [Unreleased]: https://github.com/example-org/example-repo/compare/@scope/a@2.0.0...HEAD
+              [2.0.0]: https://github.com/example-org/example-repo/compare/@scope/a@1.0.0...@scope/a@2.0.0
+              [1.0.0]: https://github.com/example-org/example-repo/releases/tag/@scope/a@1.0.0
+            `),
+          );
+          expect(
+            await environment.readFileWithinPackage('b', 'CHANGELOG.md'),
+          ).toStrictEqual(
+            buildChangelog(`
+            ## [Unreleased]
+
+            ## [1.0.0]
+            ### Added
+            - Initial release
+
+            [Unreleased]: https://github.com/example-org/example-repo/compare/@scope/b@1.0.0...HEAD
+            [1.0.0]: https://github.com/example-org/example-repo/releases/tag/@scope/b@1.0.0
+            `),
+          );
+        },
+      );
+    });
+
+    it('updates package changelogs with package changes since the last root release if this is the first package release', async () => {
+      await withMonorepoProjectEnvironment(
+        {
+          packages: {
+            $root$: {
+              name: '@scope/monorepo',
+              version: '1.0.0',
+              directoryPath: '.',
+            },
+            a: {
+              name: '@scope/a',
+              version: '0.0.0',
+              directoryPath: 'packages/a',
+            },
+            b: {
+              name: '@scope/b',
+              version: '1.0.0',
+              directoryPath: 'packages/b',
+            },
+          },
+          workspaces: {
+            '.': ['packages/*'],
+          },
+          createInitialCommit: false,
+        },
+        async (environment) => {
+          // Create an initial commit
+          await environment.writeFileWithinPackage(
+            'a',
+            'CHANGELOG.md',
+            buildChangelog(`
+            ## [Unreleased]
+
+            [Unreleased]: https://github.com/example-org/example-repo
+            `),
+          );
+          await environment.writeFileWithinPackage(
+            'b',
+            'CHANGELOG.md',
+            buildChangelog(`
+            ## [Unreleased]
+
+            ## [1.0.0]
+            ### Added
+            - Initial release
+
+            [Unreleased]: https://github.com/example-org/example-repo/compare/@scope/b@1.0.0...HEAD
+            [1.0.0]: https://github.com/example-org/example-repo/releases/tag/@scope/b@1.0.0
+            `),
+          );
+          await environment.createCommit('Initial commit');
+          await environment.runCommand('git', ['tag', '@scope/b@1.0.0']);
+          await environment.runCommand('git', ['tag', 'v1.0.0']);
+
+          // Create another commit that only changes "a"
+          await environment.writeFileWithinPackage(
+            'a',
+            'dummy.txt',
+            'Some content',
+          );
+          await environment.createCommit('Update "a"');
+
+          // Run the tool
+          await environment.runTool({
+            releaseSpecification: {
+              packages: {
+                a: 'major',
+              },
+            },
+          });
+
+          // Only "a" should be updated
+          expect(
+            await environment.readFileWithinPackage('a', 'CHANGELOG.md'),
+          ).toStrictEqual(
+            buildChangelog(`
+              ## [Unreleased]
+
+              ## [1.0.0]
+              ### Uncategorized
+              - Update "a"
+
+              [Unreleased]: https://github.com/example-org/example-repo/compare/@scope/a@1.0.0...HEAD
+              [1.0.0]: https://github.com/example-org/example-repo/releases/tag/@scope/a@1.0.0
+            `),
+          );
+          expect(
+            await environment.readFileWithinPackage('b', 'CHANGELOG.md'),
+          ).toStrictEqual(
+            buildChangelog(`
+            ## [Unreleased]
+
+            ## [1.0.0]
+            ### Added
+            - Initial release
+
+            [Unreleased]: https://github.com/example-org/example-repo/compare/@scope/b@1.0.0...HEAD
+            [1.0.0]: https://github.com/example-org/example-repo/releases/tag/@scope/b@1.0.0
+            `),
+          );
+        },
+      );
+    });
+
     it('switches to a new release branch and commits the changes', async () => {
       await withMonorepoProjectEnvironment(
         {

--- a/src/package.test.ts
+++ b/src/package.test.ts
@@ -474,6 +474,7 @@ describe('package', () => {
             isReleaseCandidate: true,
             projectRootDirectory: sandbox.directoryPath,
             repoUrl: 'https://repo.url',
+            tagPrefixes: ['package@', 'v'],
           })
           .mockResolvedValue('new changelog');
         await fs.promises.writeFile(changelogPath, 'existing changelog');

--- a/src/package.ts
+++ b/src/package.ts
@@ -271,6 +271,7 @@ async function updatePackageChangelog({
     isReleaseCandidate: true,
     projectRootDirectory: pkg.directoryPath,
     repoUrl: repositoryUrl,
+    tagPrefixes: [`${pkg.validatedManifest.name}@`, 'v'],
   });
 
   if (newChangelogContent) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -873,9 +873,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/auto-changelog@npm:^2.3.0":
-  version: 2.6.1
-  resolution: "@metamask/auto-changelog@npm:2.6.1"
+"@metamask/auto-changelog@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@metamask/auto-changelog@npm:3.0.0"
   dependencies:
     diff: ^5.0.0
     execa: ^5.1.1
@@ -883,7 +883,7 @@ __metadata:
     yargs: ^17.0.1
   bin:
     auto-changelog: dist/cli.js
-  checksum: 6ae84de492e4aec710ff2dd793f258b7cc3aba3fdeb416c0d3ab55a156da61b4ccd3272e9a6608f32b71695dc42b527a380ce62566e387240665556c8da26de3
+  checksum: ee6f41b466e8f0deb8bc454936513602c4767b7be94f704da3579e3100154c92779dcfde542076158138d5fcfb64ce491ab7fc30248ae097c7d903be0cad9fb4
   languageName: node
   linkType: hard
 
@@ -893,7 +893,7 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": ^2.0.3
     "@metamask/action-utils": ^0.0.2
-    "@metamask/auto-changelog": ^2.3.0
+    "@metamask/auto-changelog": ^3.0.0
     "@metamask/eslint-config": ^10.0.0
     "@metamask/eslint-config-jest": ^10.0.0
     "@metamask/eslint-config-nodejs": ^10.0.0


### PR DESCRIPTION
Packages within a monorepo should now have their changelogs correctly updated. Previously the update step was incorrectly expecting the monorepo package to be using a tag of the format `v[version]`. This is not how we tag packages within an indepentently versioned monorepo because we need some way to distinguish the tags used for each project.

This step has been updated to specify the expected tag prefix as being the package name followed by `@`.

Fixes #43