### PR TITLE
Add `.yml` extension to `RELEASE_SPEC` file

### DIFF
--- a/src/functional.test.ts
+++ b/src/functional.test.ts
@@ -673,7 +673,7 @@ The release spec file has been retained for you to edit again and make the neces
             {
               replacements: [
                 {
-                  from: `${environment.tempDirectoryPath}/RELEASE_SPEC`,
+                  from: `${environment.tempDirectoryPath}/RELEASE_SPEC.yml`,
                   to: '<<release-spec-file-path>>',
                 },
               ],

--- a/src/monorepo-workflow-operations.test.ts
+++ b/src/monorepo-workflow-operations.test.ts
@@ -185,7 +185,7 @@ async function setupFollowMonorepoWorkflow({
   const editor = buildMockEditor();
   const releaseSpecificationPath = path.join(
     sandbox.directoryPath,
-    'RELEASE_SPEC',
+    'RELEASE_SPEC.yml',
   );
   const releaseSpecification = buildMockReleaseSpecification({
     path: releaseSpecificationPath,

--- a/src/monorepo-workflow-operations.ts
+++ b/src/monorepo-workflow-operations.ts
@@ -64,7 +64,10 @@ export async function followMonorepoWorkflow({
   stdout: Pick<WriteStream, 'write'>;
   stderr: Pick<WriteStream, 'write'>;
 }) {
-  const releaseSpecificationPath = path.join(tempDirectoryPath, 'RELEASE_SPEC');
+  const releaseSpecificationPath = path.join(
+    tempDirectoryPath,
+    'RELEASE_SPEC.yml',
+  );
 
   if (
     !firstRemovingExistingReleaseSpecification &&


### PR DESCRIPTION
The release spec file is a YAML file, but right now does not have an extension. I've added an extension to the file to ensure that editors supporting YAML read the file as such, mainly so it adds syntax highlighting.