### PR TITLE
Add support for nested workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@metamask/utils": "^5.0.2",
     "debug": "^4.3.4",
     "execa": "^5.1.1",
-    "glob": "^10.2.2",
     "pony-cause": "^2.1.9",
     "semver": "^7.5.0",
     "which": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/action-utils": "^0.0.2",
+    "@metamask/action-utils": "^1.0.0",
     "@metamask/utils": "^5.0.2",
     "debug": "^4.3.4",
     "execa": "^5.1.1",

--- a/src/functional.test.ts
+++ b/src/functional.test.ts
@@ -1,7 +1,7 @@
 import { withMonorepoProjectEnvironment } from '../tests/functional/helpers/with';
 import { buildChangelog } from '../tests/functional/helpers/utils';
 
-jest.setTimeout(60_000);
+jest.setTimeout(10_000);
 
 describe('create-release-branch (functional)', () => {
   describe('against a monorepo with independent versions', () => {

--- a/src/functional.test.ts
+++ b/src/functional.test.ts
@@ -1,6 +1,8 @@
 import { withMonorepoProjectEnvironment } from '../tests/functional/helpers/with';
 import { buildChangelog } from '../tests/functional/helpers/utils';
 
+jest.setTimeout(60_000);
+
 describe('create-release-branch (functional)', () => {
   describe('against a monorepo with independent versions', () => {
     it('bumps the ordinary part of the root package and updates the versions of the specified packages according to the release spec', async () => {
@@ -654,16 +656,16 @@ Error: Your release spec could not be processed due to the following issues:
 
 * The following packages, which have changed since their latest release, are missing.
 
-  - @scope/d
   - @scope/b
+  - @scope/d
 
   Consider including them in the release spec so that any packages that rely on them won't break in production.
 
   If you are ABSOLUTELY SURE that this won't occur, however, and want to postpone the release of a package, then list it with a directive of "intentionally-skip". For example:
 
     packages:
-      "@scope/d": intentionally-skip
       "@scope/b": intentionally-skip
+      "@scope/d": intentionally-skip
 
 The release spec file has been retained for you to edit again and make the necessary fixes. Once you've done this, re-run this tool.
 

--- a/src/misc-utils.ts
+++ b/src/misc-utils.ts
@@ -155,7 +155,7 @@ export async function getStdoutFromCommand(
 }
 
 /**
- * Runs a Git command, splitting up the immediate output into lines.
+ * Run a command, splitting up the immediate output into lines.
  *
  * @param command - The command to execute.
  * @param args - The positional arguments to the command.

--- a/src/project.test.ts
+++ b/src/project.test.ts
@@ -7,9 +7,11 @@ import { buildMockPackage, createNoopWriteStream } from '../tests/unit/helpers';
 import { readProject } from './project';
 import * as packageModule from './package';
 import * as repoModule from './repo';
+import * as miscUtilsModule from './misc-utils';
 
 jest.mock('./package');
 jest.mock('./repo');
+jest.mock('./misc-utils');
 
 describe('project', () => {
   describe('readProject', () => {
@@ -57,6 +59,18 @@ describe('project', () => {
             projectTagNames,
           })
           .mockResolvedValue(rootPackage);
+        when(jest.spyOn(miscUtilsModule, 'getLinesFromCommand'))
+          .calledWith(
+            'yarn',
+            ['workspaces', 'list', '--no-private', '--json'],
+            {
+              cwd: projectDirectoryPath,
+            },
+          )
+          .mockResolvedValue([
+            '{"location":"packages/a","name":"a","workspaceDependencies":[],"mismatchedWorkspaceDependencies":[],"workspaceDependents":[]}',
+            '{"location":"packages/subpackages/b","name":"b","workspaceDependencies":[],"mismatchedWorkspaceDependencies":[],"workspaceDependents":[]}',
+          ]);
         when(jest.spyOn(packageModule, 'readMonorepoWorkspacePackage'))
           .calledWith({
             packageDirectoryPath: path.join(

--- a/src/project.test.ts
+++ b/src/project.test.ts
@@ -2,16 +2,19 @@ import fs from 'fs';
 import path from 'path';
 import { when } from 'jest-when';
 import { SemVer } from 'semver';
+import * as actionUtils from '@metamask/action-utils';
 import { withSandbox } from '../tests/helpers';
 import { buildMockPackage, createNoopWriteStream } from '../tests/unit/helpers';
 import { readProject } from './project';
 import * as packageModule from './package';
 import * as repoModule from './repo';
-import * as miscUtilsModule from './misc-utils';
 
 jest.mock('./package');
 jest.mock('./repo');
-jest.mock('./misc-utils');
+jest.mock('@metamask/action-utils', () => ({
+  ...jest.requireActual('@metamask/action-utils'),
+  getWorkspaceLocations: jest.fn(),
+}));
 
 describe('project', () => {
   describe('readProject', () => {
@@ -59,14 +62,9 @@ describe('project', () => {
             projectTagNames,
           })
           .mockResolvedValue(rootPackage);
-        when(jest.spyOn(miscUtilsModule, 'getLinesFromCommand'))
-          .calledWith('yarn', ['workspaces', 'list', '--json'], {
-            cwd: projectDirectoryPath,
-          })
-          .mockResolvedValue([
-            '{"location":"packages/a","name":"a","workspaceDependencies":[],"mismatchedWorkspaceDependencies":[],"workspaceDependents":[]}',
-            '{"location":"packages/subpackages/b","name":"b","workspaceDependencies":[],"mismatchedWorkspaceDependencies":[],"workspaceDependents":[]}',
-          ]);
+        when(
+          jest.spyOn(actionUtils, 'getWorkspaceLocations'),
+        ).mockResolvedValue(['packages/a', 'packages/subpackages/b']);
         when(jest.spyOn(packageModule, 'readMonorepoWorkspacePackage'))
           .calledWith({
             packageDirectoryPath: path.join(

--- a/src/project.test.ts
+++ b/src/project.test.ts
@@ -60,13 +60,9 @@ describe('project', () => {
           })
           .mockResolvedValue(rootPackage);
         when(jest.spyOn(miscUtilsModule, 'getLinesFromCommand'))
-          .calledWith(
-            'yarn',
-            ['workspaces', 'list', '--no-private', '--json'],
-            {
-              cwd: projectDirectoryPath,
-            },
-          )
+          .calledWith('yarn', ['workspaces', 'list', '--json'], {
+            cwd: projectDirectoryPath,
+          })
           .mockResolvedValue([
             '{"location":"packages/a","name":"a","workspaceDependencies":[],"mismatchedWorkspaceDependencies":[],"workspaceDependents":[]}',
             '{"location":"packages/subpackages/b","name":"b","workspaceDependencies":[],"mismatchedWorkspaceDependencies":[],"workspaceDependents":[]}',

--- a/src/project.ts
+++ b/src/project.ts
@@ -8,7 +8,6 @@ import {
 } from './package';
 import { getRepositoryHttpsUrl, getTagNames } from './repo';
 import { SemVer } from './semver';
-import { getLinesFromCommand } from './misc-utils';
 import { PackageManifestFieldNames } from './package-manifest';
 
 /**

--- a/src/project.ts
+++ b/src/project.ts
@@ -77,13 +77,15 @@ function examineReleaseVersion(packageVersion: SemVer): ReleaseVersion {
 export async function listWorkspaces(projectDirectoryPath: string) {
   const stdout = await getLinesFromCommand(
     'yarn',
-    ['workspaces', 'list', '--no-private', '--json'],
+    ['workspaces', 'list', '--json'],
     {
       cwd: projectDirectoryPath,
     },
   );
 
-  return stdout.map((line) => JSON.parse(line) as YarnWorkspace);
+  return stdout
+    .map((line) => JSON.parse(line) as YarnWorkspace)
+    .filter(({ location }) => location !== '.');
 }
 
 /**

--- a/src/project.ts
+++ b/src/project.ts
@@ -28,11 +28,6 @@ type ReleaseVersion = {
   backportNumber: number;
 };
 
-export type YarnWorkspace = {
-  location: string;
-  name: string;
-};
-
 /**
  * Represents the entire codebase on which this tool is operating.
  *

--- a/tests/functional/helpers/local-monorepo.ts
+++ b/tests/functional/helpers/local-monorepo.ts
@@ -53,7 +53,6 @@ export default class LocalMonorepo<
   async create() {
     await super.create();
     await this.runCommand('yarn', ['set', 'version', 'stable']);
-    await this.runCommand('yarn');
   }
 
   /**

--- a/tests/functional/helpers/local-monorepo.ts
+++ b/tests/functional/helpers/local-monorepo.ts
@@ -50,11 +50,6 @@ export default class LocalMonorepo<
     this.#workspaces = workspaces;
   }
 
-  async create() {
-    await super.create();
-    await this.runCommand('yarn', ['set', 'version', 'stable']);
-  }
-
   /**
    * Reads a file within a workspace package within the project.
    *

--- a/tests/functional/helpers/local-monorepo.ts
+++ b/tests/functional/helpers/local-monorepo.ts
@@ -50,6 +50,12 @@ export default class LocalMonorepo<
     this.#workspaces = workspaces;
   }
 
+  async create() {
+    await super.create();
+    await this.runCommand('yarn', ['set', 'version', 'stable']);
+    await this.runCommand('yarn');
+  }
+
   /**
    * Reads a file within a workspace package within the project.
    *

--- a/yarn.lock
+++ b/yarn.lock
@@ -946,14 +946,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/action-utils@npm:^0.0.2":
-  version: 0.0.2
-  resolution: "@metamask/action-utils@npm:0.0.2"
+"@metamask/action-utils@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@metamask/action-utils@npm:1.0.0"
   dependencies:
     "@types/semver": ^7.3.6
     glob: ^7.1.7
     semver: ^7.3.5
-  checksum: 4d3552d77a329791e2b1da0ca5023e9e04c1920c61f06ef070e8b4f4f072dd1f632124003964d47cdebf314a621a12d7209fbdd6871db37cfa1330a6ed679a11
+  checksum: 5cfd5c7f8895f4bc602cb6e7b3e133aae0431ded8f50e136d314b2e54936ae22cc6add226fa6dfabb300addf084e32fd864a87b91af9188fa158b6e99d91e784
   languageName: node
   linkType: hard
 
@@ -976,7 +976,7 @@ __metadata:
   resolution: "@metamask/create-release-branch@workspace:."
   dependencies:
     "@lavamoat/allow-scripts": ^2.3.1
-    "@metamask/action-utils": ^0.0.2
+    "@metamask/action-utils": ^1.0.0
     "@metamask/auto-changelog": ^3.0.0
     "@metamask/eslint-config": ^10.0.0
     "@metamask/eslint-config-jest": ^10.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1002,7 +1002,6 @@ __metadata:
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^4.2.1
     execa: ^5.1.1
-    glob: ^10.2.2
     jest: ^29.5.0
     jest-it-up: ^2.0.2
     jest-when: ^3.5.2
@@ -3160,7 +3159,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.0.0, glob@npm:^10.2.2":
+"glob@npm:^10.0.0":
   version: 10.2.2
   resolution: "glob@npm:10.2.2"
   dependencies:


### PR DESCRIPTION
This adds support for nested workspaces (workspaces in workspaces), by updating the logic to fetch workspaces. Rather than looking at the root `package.json`, it now runs `yarn workspaces list --no-private` to get a list of all workspaces.