### PR TITLE
fix: replace `null` with `intentionally-skip` in release-spec template comment

### DIFF
--- a/src/release-specification.test.ts
+++ b/src/release-specification.test.ts
@@ -53,7 +53,7 @@ describe('release-specification', () => {
 # - "minor" (if you want to bump the minor part of the package's version)
 # - "patch" (if you want to bump the patch part of the package's version)
 # - an exact version with major, minor, and patch parts (e.g. "1.2.3")
-# - null (to skip the package entirely)
+# - intentionally-skip (to skip the package entirely)
 #
 # When you're finished making your selections, save this file and
 # create-release-branch will continue automatically.
@@ -116,7 +116,7 @@ packages:
 # - "minor" (if you want to bump the minor part of the package's version)
 # - "patch" (if you want to bump the patch part of the package's version)
 # - an exact version with major, minor, and patch parts (e.g. "1.2.3")
-# - null (to skip the package entirely)
+# - intentionally-skip (to skip the package entirely)
 #
 # When you're finished making your selections, save this file and then re-run
 # create-release-branch.

--- a/src/release-specification.ts
+++ b/src/release-specification.ts
@@ -77,7 +77,7 @@ export async function generateReleaseSpecificationTemplateForMonorepo({
 # - "minor" (if you want to bump the minor part of the package's version)
 # - "patch" (if you want to bump the patch part of the package's version)
 # - an exact version with major, minor, and patch parts (e.g. "1.2.3")
-# - null (to skip the package entirely)
+# - intentionally-skip (to skip the package entirely)
 #
 ${afterEditingInstructions}
   `.trim();


### PR DESCRIPTION
Alternative to #92 to make the current behavior more immediately obvious and the comment more helpful.