### PR TITLE
Update Package Reader to Accept Range Versions in Dependencies

### DIFF
--- a/src/package-manifest.test.ts
+++ b/src/package-manifest.test.ts
@@ -64,6 +64,8 @@ describe('package-manifest', () => {
           private: true,
           dependencies: {
             a: '1.0.0',
+            b: '^2.0.0',
+            c: '~4.3.0',
           },
         };
         const validated = {
@@ -73,6 +75,8 @@ describe('package-manifest', () => {
           private: true,
           dependencies: {
             a: '1.0.0',
+            b: '^2.0.0',
+            c: '~4.3.0',
           },
           peerDependencies: {},
         };
@@ -94,6 +98,8 @@ describe('package-manifest', () => {
           private: true,
           peerDependencies: {
             a: '1.0.0',
+            b: '^2.0.0',
+            c: '~4.3.0',
           },
         };
         const validated = {
@@ -104,6 +110,8 @@ describe('package-manifest', () => {
           dependencies: {},
           peerDependencies: {
             a: '1.0.0',
+            b: '^2.0.0',
+            c: '~4.3.0',
           },
         };
         await fs.promises.writeFile(manifestPath, JSON.stringify(unvalidated));

--- a/src/package-manifest.ts
+++ b/src/package-manifest.ts
@@ -6,7 +6,7 @@ import {
 import { isPlainObject } from '@metamask/utils';
 import { readJsonObjectFile } from './fs';
 import { isTruthyString } from './misc-utils';
-import { isValidSemver, SemVer } from './semver';
+import { semver, SemVer } from './semver';
 
 export { PackageManifestFieldNames, PackageManifestDependenciesFieldNames };
 
@@ -139,7 +139,7 @@ export function readPackageManifestNameField(
 function isValidPackageManifestVersionField(
   version: unknown,
 ): version is string {
-  return isTruthyString(version) && isValidSemver(version);
+  return isTruthyString(version) && semver.validRange(version) !== null;
 }
 
 /**


### PR DESCRIPTION
The recent merges from https://github.com/MetaMask/create-release-branch/pull/102 and https://github.com/MetaMask/create-release-branch/pull/101 have introduced a bug related to package version validation. Specifically, the issue arises when handling range versions, which are currently not permitted by the validation logic.