### PR TITLE
Quote `editor.path` argument

### DIFF
--- a/src/release-specification.ts
+++ b/src/release-specification.ts
@@ -123,7 +123,7 @@ export async function waitForUserToEditReleaseSpecification(
   );
 
   const promiseForEditorCommand = runCommand(
-    editor.path,
+    `"${editor.path}"`,
     [...editor.args, releaseSpecificationPath],
     {
       stdio: 'inherit',


### PR DESCRIPTION
The `editor.path` string can contain spaces, e.g. `/Applications/Visual Studio Code.app/...`. This string is passed to `execa()`, which attempts to execute it as a command in the user's shell. On some systems, this string must be quoted, or else the shell will interpret the substring until the first space as the command, and either error or execute the wrong thing.