### PR TITLE
Move auto-changelog to deps, pin to ~3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@metamask/action-utils": "^1.0.0",
+    "@metamask/auto-changelog": "~3.3.0",
     "@metamask/utils": "^8.2.1",
     "debug": "^4.3.4",
     "execa": "^5.1.1",
@@ -37,7 +38,6 @@
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.3.1",
-    "@metamask/auto-changelog": "^3.0.0",
     "@metamask/eslint-config": "^10.0.0",
     "@metamask/eslint-config-jest": "^10.0.0",
     "@metamask/eslint-config-nodejs": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1070,17 +1070,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/auto-changelog@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "@metamask/auto-changelog@npm:3.1.0"
+"@metamask/auto-changelog@npm:~3.3.0":
+  version: 3.3.0
+  resolution: "@metamask/auto-changelog@npm:3.3.0"
   dependencies:
     diff: ^5.0.0
     execa: ^5.1.1
+    prettier: ^2.8.8
     semver: ^7.3.5
     yargs: ^17.0.1
   bin:
     auto-changelog: dist/cli.js
-  checksum: cd3c833100c19a80e0b7ae8c174fbbe225700eef5fbabd9b0d6c4b439c8af839792111a17d9ddf2e1939839736413afd7402d2cc08ece373622b5a410da5e9fe
+  checksum: 1b308f0f6beafb479da19398bc51315888c8fa7e1688ee835a96d5e2ca8dccf2edac80ac835335122b2c3ff6c76f03d202a35316122bbfa7c071954d5227f732
   languageName: node
   linkType: hard
 
@@ -1090,7 +1091,7 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": ^2.3.1
     "@metamask/action-utils": ^1.0.0
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ~3.3.0
     "@metamask/eslint-config": ^10.0.0
     "@metamask/eslint-config-jest": ^10.0.0
     "@metamask/eslint-config-nodejs": ^10.0.0
@@ -5240,6 +5241,15 @@ __metadata:
   bin:
     prettier: bin-prettier.js
   checksum: 55a4409182260866ab31284d929b3cb961e5fdb91fe0d2e099dac92eaecec890f36e524b4c19e6ceae839c99c6d7195817579cdffc8e2c80da0cb794463a748b
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^2.8.8":
+  version: 2.8.8
+  resolution: "prettier@npm:2.8.8"
+  bin:
+    prettier: bin-prettier.js
+  checksum: b49e409431bf129dd89238d64299ba80717b57ff5a6d1c1a8b1a28b590d998a34e083fa13573bc732bb8d2305becb4c9a4407f8486c81fa7d55100eb08263cf8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We started to use `@metamask/auto-changelog` at runtime in a recent commit. As it turns out, recent versions of this tool contain breaking changes that we didn't document, and so we need to rely on an older version. Adding this to `dependencies` ensures that we are doing so, even if the project where this tool is run against a project that also also uses `@metamask/auto-changelog` (but a different version).