### PR TITLE
Support 'workspace:^' notation in dependency versions

### DIFF
--- a/src/package-manifest.test.ts
+++ b/src/package-manifest.test.ts
@@ -66,6 +66,7 @@ describe('package-manifest', () => {
             a: '1.0.0',
             b: '^2.0.0',
             c: '~4.3.0',
+            d: 'workspace:^',
           },
         };
         const validated = {
@@ -77,6 +78,7 @@ describe('package-manifest', () => {
             a: '1.0.0',
             b: '^2.0.0',
             c: '~4.3.0',
+            d: 'workspace:^',
           },
           peerDependencies: {},
         };
@@ -100,6 +102,7 @@ describe('package-manifest', () => {
             a: '1.0.0',
             b: '^2.0.0',
             c: '~4.3.0',
+            d: 'workspace:^',
           },
         };
         const validated = {
@@ -112,6 +115,7 @@ describe('package-manifest', () => {
             a: '1.0.0',
             b: '^2.0.0',
             c: '~4.3.0',
+            d: 'workspace:^',
           },
         };
         await fs.promises.writeFile(manifestPath, JSON.stringify(unvalidated));

--- a/src/package-manifest.ts
+++ b/src/package-manifest.ts
@@ -139,7 +139,7 @@ export function readPackageManifestNameField(
 function isValidPackageManifestVersionField(
   version: unknown,
 ): version is string {
-  return isTruthyString(version);
+  return isTruthyString(version) && semver.validRange(version) !== null;
 }
 
 /**
@@ -156,8 +156,7 @@ function isValidPackageManifestDependencyValue(
   version: unknown,
 ): version is string {
   return (
-    isValidPackageManifestVersionField(version) &&
-    (semver.validRange(version) !== null || version === 'workspace:^')
+    isValidPackageManifestVersionField(version) || version === 'workspace:^'
   );
 }
 

--- a/src/package-manifest.ts
+++ b/src/package-manifest.ts
@@ -139,7 +139,10 @@ export function readPackageManifestNameField(
 function isValidPackageManifestVersionField(
   version: unknown,
 ): version is string {
-  return isTruthyString(version) && semver.validRange(version) !== null;
+  return (
+    (isTruthyString(version) && semver.validRange(version) !== null) ||
+    version === 'workspace:^'
+  );
 }
 
 /**

--- a/src/package-manifest.ts
+++ b/src/package-manifest.ts
@@ -139,9 +139,25 @@ export function readPackageManifestNameField(
 function isValidPackageManifestVersionField(
   version: unknown,
 ): version is string {
+  return isTruthyString(version);
+}
+
+/**
+ * Type guard to ensure that the provided version value is a valid dependency version
+ * specifier for a package manifest. This function validates both semantic versioning
+ * ranges and the special 'workspace:^' notation.
+ *
+ * @param version - The value to check.
+ * @returns `true` if the version is a valid string that either
+ * represents a semantic versioning range or is exactly 'workspace:^'.
+ * Otherwise, it returns `false`.
+ */
+function isValidPackageManifestDependencyValue(
+  version: unknown,
+): version is string {
   return (
-    (isTruthyString(version) && semver.validRange(version) !== null) ||
-    version === 'workspace:^'
+    isValidPackageManifestVersionField(version) &&
+    (semver.validRange(version) !== null || version === 'workspace:^')
   );
 }
 
@@ -288,7 +304,8 @@ function isValidPackageManifestDependenciesField(
     (isPlainObject(depsValue) &&
       Object.entries(depsValue).every(([pkgName, version]) => {
         return (
-          isTruthyString(pkgName) && isValidPackageManifestVersionField(version)
+          isTruthyString(pkgName) &&
+          isValidPackageManifestDependencyValue(version)
         );
       }))
   );


### PR DESCRIPTION
### Overview

This pull request addresses the issue where the 'workspace:^' notation was not being recognized as a valid specifier for dependency/peerDependencies versions in our package.json files.

### Changes Made

- Modified `isValidPackageManifestVersionField` to recognize `workspace:^` as a valid version.