### PR TITLE
feat: allow `npm:name@version` dependency redirections in manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "execa": "^8.0.1",
     "pony-cause": "^2.1.9",
     "semver": "^7.5.4",
+    "validate-npm-package-name": "^5.0.0",
     "which": "^3.0.0",
     "yaml": "^2.2.2",
     "yargs": "^17.7.1"
@@ -52,6 +53,7 @@
     "@types/node": "^17.0.23",
     "@types/prettier": "^2.7.3",
     "@types/rimraf": "^4.0.5",
+    "@types/validate-npm-package-name": "^4.0.2",
     "@types/which": "^3.0.0",
     "@types/yargs": "^17.0.10",
     "@typescript-eslint/eslint-plugin": "^5.62.0",

--- a/src/package-manifest.test.ts
+++ b/src/package-manifest.test.ts
@@ -67,6 +67,7 @@ describe('package-manifest', () => {
             b: '^2.0.0',
             c: '~4.3.0',
             d: 'workspace:^',
+            e: 'npm:a@^2.0.0',
           },
         };
         const validated = {
@@ -79,6 +80,7 @@ describe('package-manifest', () => {
             b: '^2.0.0',
             c: '~4.3.0',
             d: 'workspace:^',
+            e: 'npm:a@^2.0.0',
           },
           peerDependencies: {},
         };

--- a/src/package-manifest.test.ts
+++ b/src/package-manifest.test.ts
@@ -67,7 +67,7 @@ describe('package-manifest', () => {
             b: '^2.0.0',
             c: '~4.3.0',
             d: 'workspace:^',
-            e: 'npm:a@^2.0.0',
+            e: 'npm:@a/abc@^2.0.0',
           },
         };
         const validated = {
@@ -80,7 +80,7 @@ describe('package-manifest', () => {
             b: '^2.0.0',
             c: '~4.3.0',
             d: 'workspace:^',
-            e: 'npm:a@^2.0.0',
+            e: 'npm:@a/abc@^2.0.0',
           },
           peerDependencies: {},
         };
@@ -317,7 +317,9 @@ describe('package-manifest', () => {
             name: 'foo',
             version: '1.0.0',
             peerDependencies: {
-              a: 12345,
+              a: 'npm:@foo',
+              b: 'npm:foo@',
+              c: '12345',
             },
           }),
         );

--- a/src/package-manifest.ts
+++ b/src/package-manifest.ts
@@ -174,7 +174,8 @@ function isValidPackageManifestDependencyValue(
   try {
     const redirectedDependencyMatch = redirectedDependencyRegexp.exec(version);
 
-    if (!redirectedDependencyMatch || redirectedDependencyMatch.length < 3) {
+    /* istanbul ignore if */
+    if (!redirectedDependencyMatch) {
       return false;
     }
 
@@ -183,7 +184,7 @@ function isValidPackageManifestDependencyValue(
       validateNPMPackageName(redirectedName)?.validForOldPackages &&
       isValidPackageManifestVersionField(redirectedVersion)
     );
-  } catch (e) {
+  } catch (e) /* istanbul ignore next */ {
     return false;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2090,6 +2090,7 @@ __metadata:
     "@types/node": ^17.0.23
     "@types/prettier": ^2.7.3
     "@types/rimraf": ^4.0.5
+    "@types/validate-npm-package-name": ^4.0.2
     "@types/which": ^3.0.0
     "@types/yargs": ^17.0.10
     "@typescript-eslint/eslint-plugin": ^5.62.0
@@ -2117,6 +2118,7 @@ __metadata:
     stdio-mock: ^1.2.0
     tsx: ^4.6.1
     typescript: ~5.1.6
+    validate-npm-package-name: ^5.0.0
     which: ^3.0.0
     yaml: ^2.2.2
     yargs: ^17.7.1
@@ -2603,6 +2605,13 @@ __metadata:
   version: 2.0.1
   resolution: "@types/stack-utils@npm:2.0.1"
   checksum: 205fdbe3326b7046d7eaf5e494d8084f2659086a266f3f9cf00bccc549c8e36e407f88168ad4383c8b07099957ad669f75f2532ed4bc70be2b037330f7bae019
+  languageName: node
+  linkType: hard
+
+"@types/validate-npm-package-name@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@types/validate-npm-package-name@npm:4.0.2"
+  checksum: 3f35a3cc8ddd919b456843f36d55a4f1df5f03d5d9b6494b4d8f5f3b24e3f24a11c922772d9970a67f1249214da18c157776e9c6d2e72227799459849dfd9c76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This allows specifying dependency versions in the format `npm:{x}@{y}`, where:
- `x` is valid package name
- `y` is valid semver range

---

The package is currently experiencing failure running in https://github.com/MetaMask/core/ due to https://github.com/MetaMask/core/blob/main/packages/controller-utils/package.json#L58.

This fixes that.