### PR TITLE
[3.x] feat: allow `npm:name@version` dependency redirections in manifest (#158)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "execa": "^8.0.1",
     "pony-cause": "^2.1.9",
     "semver": "^7.5.4",
+    "validate-npm-package-name": "^5.0.0",
     "which": "^3.0.0",
     "yaml": "^2.2.2",
     "yargs": "^17.7.1"
@@ -52,6 +53,7 @@
     "@types/node": "^17.0.23",
     "@types/prettier": "^2.7.3",
     "@types/rimraf": "^4.0.5",
+    "@types/validate-npm-package-name": "^4.0.2",
     "@types/which": "^3.0.0",
     "@types/yargs": "^17.0.10",
     "@typescript-eslint/eslint-plugin": "^5.62.0",

--- a/src/package-manifest.test.ts
+++ b/src/package-manifest.test.ts
@@ -67,6 +67,7 @@ describe('package-manifest', () => {
             b: '^2.0.0',
             c: '~4.3.0',
             d: 'workspace:^',
+            e: 'npm:@a/abc@^2.0.0',
           },
         };
         const validated = {
@@ -79,6 +80,7 @@ describe('package-manifest', () => {
             b: '^2.0.0',
             c: '~4.3.0',
             d: 'workspace:^',
+            e: 'npm:@a/abc@^2.0.0',
           },
           peerDependencies: {},
         };
@@ -315,7 +317,9 @@ describe('package-manifest', () => {
             name: 'foo',
             version: '1.0.0',
             peerDependencies: {
-              a: 12345,
+              a: 'npm:@foo',
+              b: 'npm:foo@',
+              c: '12345',
             },
           }),
         );

--- a/src/package-manifest.ts
+++ b/src/package-manifest.ts
@@ -4,6 +4,7 @@ import {
   ManifestDependencyFieldNames as PackageManifestDependenciesFieldNames,
 } from '@metamask/action-utils';
 import { isPlainObject } from '@metamask/utils';
+import validateNPMPackageName from 'validate-npm-package-name';
 import { readJsonObjectFile } from './fs.js';
 import { isTruthyString } from './misc-utils.js';
 import { semver, SemVer } from './semver.js';
@@ -144,8 +145,10 @@ function isValidPackageManifestVersionField(
 
 /**
  * Type guard to ensure that the provided version value is a valid dependency version
- * specifier for a package manifest. This function validates both semantic versioning
- * ranges and the special 'workspace:^' notation.
+ * specifier for a package manifest. This function validates:
+ * semantic versioning ranges
+ * 'workspace:^' notation
+ * 'npm:{packageName}:{semverRange}' redirections.
  *
  * @param version - The value to check.
  * @returns `true` if the version is a valid string that either
@@ -155,9 +158,35 @@ function isValidPackageManifestVersionField(
 function isValidPackageManifestDependencyValue(
   version: unknown,
 ): version is string {
-  return (
-    isValidPackageManifestVersionField(version) || version === 'workspace:^'
-  );
+  if (typeof version !== 'string') {
+    return false;
+  }
+
+  if (
+    isValidPackageManifestVersionField(version) ||
+    version === 'workspace:^'
+  ) {
+    return true;
+  }
+
+  const redirectedDependencyRegexp = /^npm:(.*)@(.*?)$/u;
+
+  try {
+    const redirectedDependencyMatch = redirectedDependencyRegexp.exec(version);
+
+    /* istanbul ignore if */
+    if (!redirectedDependencyMatch) {
+      return false;
+    }
+
+    const [, redirectedName, redirectedVersion] = redirectedDependencyMatch;
+    return (
+      validateNPMPackageName(redirectedName)?.validForOldPackages &&
+      isValidPackageManifestVersionField(redirectedVersion)
+    );
+  } catch (e) /* istanbul ignore next */ {
+    return false;
+  }
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2075,6 +2075,7 @@ __metadata:
     "@types/node": ^17.0.23
     "@types/prettier": ^2.7.3
     "@types/rimraf": ^4.0.5
+    "@types/validate-npm-package-name": ^4.0.2
     "@types/which": ^3.0.0
     "@types/yargs": ^17.0.10
     "@typescript-eslint/eslint-plugin": ^5.62.0
@@ -2102,6 +2103,7 @@ __metadata:
     stdio-mock: ^1.2.0
     tsx: ^4.6.1
     typescript: ~5.1.6
+    validate-npm-package-name: ^5.0.0
     which: ^3.0.0
     yaml: ^2.2.2
     yargs: ^17.7.1
@@ -2544,6 +2546,13 @@ __metadata:
   version: 2.0.1
   resolution: "@types/stack-utils@npm:2.0.1"
   checksum: 205fdbe3326b7046d7eaf5e494d8084f2659086a266f3f9cf00bccc549c8e36e407f88168ad4383c8b07099957ad669f75f2532ed4bc70be2b037330f7bae019
+  languageName: node
+  linkType: hard
+
+"@types/validate-npm-package-name@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@types/validate-npm-package-name@npm:4.0.2"
+  checksum: 3f35a3cc8ddd919b456843f36d55a4f1df5f03d5d9b6494b4d8f5f3b24e3f24a11c922772d9970a67f1249214da18c157776e9c6d2e72227799459849dfd9c76
   languageName: node
   linkType: hard
 
@@ -7291,6 +7300,13 @@ __metadata:
     "@types/istanbul-lib-coverage": ^2.0.1
     convert-source-map: ^1.6.0
   checksum: a49c34bf0a3af0c11041a3952a2600913904a983bd1bc87148b5c033bc5c1d02d5a13620fcdbfa2c60bc582a2e2970185780f0c844b4c3a220abf405f8af6311
+  languageName: node
+  linkType: hard
+
+"validate-npm-package-name@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "validate-npm-package-name@npm:5.0.1"
+  checksum: 0d583a1af23aeffea7748742cf22b6802458736fb8b60323ba5949763824d46f796474b0e1b9206beb716f9d75269e19dbd7795d6b038b29d561be95dd827381
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- #158 targeting v3.x.