### PR TITLE
chore: bump `actions/upload-artifact` from `v3` to `v4`

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -41,7 +41,7 @@ jobs:
           release-version: ${{ github.event.inputs.release-version }}
           artifacts-path: gh-action__release-authors
       # Upload the release author artifact for use in subsequent workflows
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: release-authors
           path: gh-action__release-authors


### PR DESCRIPTION
### Description

This PR upgrades `actions/upload-artifact` from `v3` to `v4`.
Version v3 has been deprecated since `January 30th, 2025`. For more details, see: [Deprecation Notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).