### PR TITLE
fix: include unchanged dependents in release validation

### DIFF
--- a/src/release-specification.test.ts
+++ b/src/release-specification.test.ts
@@ -657,7 +657,7 @@ ${releaseSpecificationPath}
       });
     });
 
-    it('throws if there are any packages in the release with a major version bump using the word "major", but any of their dependents defined as "peerDependencies" have no changes since their latest release and are not listed in the release', async () => {
+    it('throws if there are any packages in the release with a major version bump using the word "major", but any of their dependents defined as "peerDependencies" are not listed in the release, even if they have no changes', async () => {
       await withSandbox(async (sandbox) => {
         const project = buildMockProject({
           workspacePackages: {
@@ -767,7 +767,7 @@ ${releaseSpecificationPath}
       });
     });
 
-    it('throws if there are any packages in the release with a major version bump using a literal version, but any of their dependents defined as "peerDependencies" have no changes since their latest release and are not listed in the release', async () => {
+    it('throws if there are any packages in the release with a major version bump using a literal version, but any of their dependents defined as "peerDependencies" are not listed in the release, even if they have no changes', async () => {
       await withSandbox(async (sandbox) => {
         const project = buildMockProject({
           workspacePackages: {
@@ -878,7 +878,7 @@ ${releaseSpecificationPath}
       });
     });
 
-    it('throws if there are any packages in the release with a major version bump using the word "major", but their dependents via "peerDependencies" have no changes since their latest release and have their version specified as null in the release spec', async () => {
+    it('throws if there are any packages in the release with a major version bump using the word "major", but their dependents via "peerDependencies" have their version specified as null in the release spec, even if they have no changes', async () => {
       await withSandbox(async (sandbox) => {
         const project = buildMockProject({
           workspacePackages: {
@@ -990,7 +990,7 @@ ${releaseSpecificationPath}
       });
     });
 
-    it('throws if there are any packages in the release with a major version bump using a literal version, but their dependents via "peerDependencies" have no changes since their latest release and have their version specified as null in the release spec', async () => {
+    it('throws if there are any packages in the release with a major version bump using a literal version, but their dependents via "peerDependencies" have their version specified as null in the release spec, even if they have no changes', async () => {
       await withSandbox(async (sandbox) => {
         const project = buildMockProject({
           workspacePackages: {

--- a/src/release-specification.test.ts
+++ b/src/release-specification.test.ts
@@ -602,7 +602,7 @@ Your release spec could not be processed due to the following issues:
       });
     });
 
-    it('throws if there are any packages in the release with a major version bump using the word "major", but any of their dependents defined as "peerDependencies" are not listed in the release', async () => {
+    it('throws if there are any packages in the release with a major version bump using the word "major", but any of their dependents defined as "peerDependencies" have changes since their latest release and are not listed in the release', async () => {
       await withSandbox(async (sandbox) => {
         const project = buildMockProject({
           workspacePackages: {
@@ -657,7 +657,62 @@ ${releaseSpecificationPath}
       });
     });
 
-    it('throws if there are any packages in the release with a major version bump using a literal version, but any of their dependents defined as "peerDependencies" are not listed in the release', async () => {
+    it('throws if there are any packages in the release with a major version bump using the word "major", but any of their dependents defined as "peerDependencies" have no changes since their latest release and are not listed in the release', async () => {
+      await withSandbox(async (sandbox) => {
+        const project = buildMockProject({
+          workspacePackages: {
+            a: buildMockPackage('a', {
+              hasChangesSinceLatestRelease: true,
+            }),
+            b: buildMockPackage('b', {
+              hasChangesSinceLatestRelease: false,
+              validatedManifest: {
+                peerDependencies: {
+                  a: '1.0.0',
+                },
+              },
+            }),
+          },
+        });
+        const releaseSpecificationPath = path.join(
+          sandbox.directoryPath,
+          'release-spec',
+        );
+        await fs.promises.writeFile(
+          releaseSpecificationPath,
+          YAML.stringify({
+            packages: {
+              a: 'major',
+            },
+          }),
+        );
+
+        await expect(
+          validateReleaseSpecification(project, releaseSpecificationPath),
+        ).rejects.toThrow(
+          `
+Your release spec could not be processed due to the following issues:
+
+* The following dependents of package 'a', which is being released with a major version bump, are missing from the release spec.
+
+  - b
+
+ Consider including them in the release spec so that they are compatible with the new 'a' version.
+
+  If you are ABSOLUTELY SURE these packages are safe to omit, however, and want to postpone the release of a package, then list it with a directive of "intentionally-skip". For example:
+
+    packages:
+      b: intentionally-skip
+
+The release spec file has been retained for you to edit again and make the necessary fixes. Once you've done this, re-run this tool.
+
+${releaseSpecificationPath}
+`.trim(),
+        );
+      });
+    });
+
+    it('throws if there are any packages in the release with a major version bump using a literal version, but any of their dependents defined as "peerDependencies" have changes since their latest release and are not listed in the release', async () => {
       await withSandbox(async (sandbox) => {
         const project = buildMockProject({
           workspacePackages: {
@@ -712,7 +767,62 @@ ${releaseSpecificationPath}
       });
     });
 
-    it('throws if there are any packages in the release with a major version bump using the word "major", but their dependents via "peerDependencies" have their version specified as null in the release spec', async () => {
+    it('throws if there are any packages in the release with a major version bump using a literal version, but any of their dependents defined as "peerDependencies" have no changes since their latest release and are not listed in the release', async () => {
+      await withSandbox(async (sandbox) => {
+        const project = buildMockProject({
+          workspacePackages: {
+            a: buildMockPackage('a', '2.1.4', {
+              hasChangesSinceLatestRelease: true,
+            }),
+            b: buildMockPackage('b', {
+              hasChangesSinceLatestRelease: true,
+              validatedManifest: {
+                peerDependencies: {
+                  a: '2.1.4',
+                },
+              },
+            }),
+          },
+        });
+        const releaseSpecificationPath = path.join(
+          sandbox.directoryPath,
+          'release-spec',
+        );
+        await fs.promises.writeFile(
+          releaseSpecificationPath,
+          YAML.stringify({
+            packages: {
+              a: '3.0.0',
+            },
+          }),
+        );
+
+        await expect(
+          validateReleaseSpecification(project, releaseSpecificationPath),
+        ).rejects.toThrow(
+          `
+Your release spec could not be processed due to the following issues:
+
+* The following dependents of package 'a', which is being released with a major version bump, are missing from the release spec.
+
+  - b
+
+ Consider including them in the release spec so that they are compatible with the new 'a' version.
+
+  If you are ABSOLUTELY SURE these packages are safe to omit, however, and want to postpone the release of a package, then list it with a directive of "intentionally-skip". For example:
+
+    packages:
+      b: intentionally-skip
+
+The release spec file has been retained for you to edit again and make the necessary fixes. Once you've done this, re-run this tool.
+
+${releaseSpecificationPath}
+`.trim(),
+        );
+      });
+    });
+
+    it('throws if there are any packages in the release with a major version bump using the word "major", but their dependents via "peerDependencies" have changes since their latest release and have their version specified as null in the release spec', async () => {
       await withSandbox(async (sandbox) => {
         const project = buildMockProject({
           workspacePackages: {
@@ -768,7 +878,63 @@ ${releaseSpecificationPath}
       });
     });
 
-    it('throws if there are any packages in the release with a major version bump using a literal version, but their dependents via "peerDependencies" have their version specified as null in the release spec', async () => {
+    it('throws if there are any packages in the release with a major version bump using the word "major", but their dependents via "peerDependencies" have no changes since their latest release and have their version specified as null in the release spec', async () => {
+      await withSandbox(async (sandbox) => {
+        const project = buildMockProject({
+          workspacePackages: {
+            a: buildMockPackage('a', {
+              hasChangesSinceLatestRelease: true,
+            }),
+            b: buildMockPackage('b', {
+              hasChangesSinceLatestRelease: false,
+              validatedManifest: {
+                peerDependencies: {
+                  a: '1.0.0',
+                },
+              },
+            }),
+          },
+        });
+        const releaseSpecificationPath = path.join(
+          sandbox.directoryPath,
+          'release-spec',
+        );
+        await fs.promises.writeFile(
+          releaseSpecificationPath,
+          YAML.stringify({
+            packages: {
+              a: 'major',
+              b: null,
+            },
+          }),
+        );
+
+        await expect(
+          validateReleaseSpecification(project, releaseSpecificationPath),
+        ).rejects.toThrow(
+          `
+Your release spec could not be processed due to the following issues:
+
+* The following dependents of package 'a', which is being released with a major version bump, are missing from the release spec.
+
+  - b
+
+ Consider including them in the release spec so that they are compatible with the new 'a' version.
+
+  If you are ABSOLUTELY SURE these packages are safe to omit, however, and want to postpone the release of a package, then list it with a directive of "intentionally-skip". For example:
+
+    packages:
+      b: intentionally-skip
+
+The release spec file has been retained for you to edit again and make the necessary fixes. Once you've done this, re-run this tool.
+
+${releaseSpecificationPath}
+`.trim(),
+        );
+      });
+    });
+
+    it('throws if there are any packages in the release with a major version bump using a literal version, but their dependents via "peerDependencies" have changes since their latest release and have their version specified as null in the release spec', async () => {
       await withSandbox(async (sandbox) => {
         const project = buildMockProject({
           workspacePackages: {
@@ -777,6 +943,62 @@ ${releaseSpecificationPath}
             }),
             b: buildMockPackage('b', {
               hasChangesSinceLatestRelease: true,
+              validatedManifest: {
+                peerDependencies: {
+                  a: '2.1.4',
+                },
+              },
+            }),
+          },
+        });
+        const releaseSpecificationPath = path.join(
+          sandbox.directoryPath,
+          'release-spec',
+        );
+        await fs.promises.writeFile(
+          releaseSpecificationPath,
+          YAML.stringify({
+            packages: {
+              a: '3.0.0',
+              b: null,
+            },
+          }),
+        );
+
+        await expect(
+          validateReleaseSpecification(project, releaseSpecificationPath),
+        ).rejects.toThrow(
+          `
+Your release spec could not be processed due to the following issues:
+
+* The following dependents of package 'a', which is being released with a major version bump, are missing from the release spec.
+
+  - b
+
+ Consider including them in the release spec so that they are compatible with the new 'a' version.
+
+  If you are ABSOLUTELY SURE these packages are safe to omit, however, and want to postpone the release of a package, then list it with a directive of "intentionally-skip". For example:
+
+    packages:
+      b: intentionally-skip
+
+The release spec file has been retained for you to edit again and make the necessary fixes. Once you've done this, re-run this tool.
+
+${releaseSpecificationPath}
+`.trim(),
+        );
+      });
+    });
+
+    it('throws if there are any packages in the release with a major version bump using a literal version, but their dependents via "peerDependencies" have no changes since their latest release and have their version specified as null in the release spec', async () => {
+      await withSandbox(async (sandbox) => {
+        const project = buildMockProject({
+          workspacePackages: {
+            a: buildMockPackage('a', '2.1.4', {
+              hasChangesSinceLatestRelease: true,
+            }),
+            b: buildMockPackage('b', {
+              hasChangesSinceLatestRelease: false,
               validatedManifest: {
                 peerDependencies: {
                   a: '2.1.4',

--- a/src/release-specification.ts
+++ b/src/release-specification.ts
@@ -172,13 +172,11 @@ export async function waitForUserToEditReleaseSpecification(
  *
  * @param project - The project containing workspace packages.
  * @param packageName - The name of the package to find dependents for.
- * @param unvalidatedReleaseSpecificationPackages - The packages in the release specification.
- * @returns An array of package names that depend on the given package and are missing from the release spec.
+ * @returns An array of package names that depend on the given package.
  */
-export function findMissingUnreleasedDependents(
+export function findAllWorkspacePackagesThatDependOnPackage(
   project: Project,
   packageName: string,
-  unvalidatedReleaseSpecificationPackages: Record<string, string | null>,
 ): string[] {
   const dependentNames = Object.keys(project.workspacePackages).filter(
     (possibleDependentName) => {
@@ -187,6 +185,27 @@ export function findMissingUnreleasedDependents(
       const { peerDependencies } = possibleDependent.validatedManifest;
       return hasProperty(peerDependencies, packageName);
     },
+  );
+
+  return dependentNames;
+}
+
+/**
+ * Finds all workspace packages that depend on the given package.
+ *
+ * @param project - The project containing workspace packages.
+ * @param packageName - The name of the package to find dependents for.
+ * @param unvalidatedReleaseSpecificationPackages - The packages in the release specification.
+ * @returns An array of package names that depend on the given package and are missing from the release spec.
+ */
+export function findMissingUnreleasedDependents(
+  project: Project,
+  packageName: string,
+  unvalidatedReleaseSpecificationPackages: Record<string, string | null>,
+): string[] {
+  const dependentNames = findAllWorkspacePackagesThatDependOnPackage(
+    project,
+    packageName,
   );
 
   return dependentNames.filter((dependentName) => {

--- a/src/release-specification.ts
+++ b/src/release-specification.ts
@@ -168,7 +168,7 @@ export async function waitForUserToEditReleaseSpecification(
 }
 
 /**
- * Finds all workspace packages that depend on the given package and have changes since their latest release.
+ * Finds all workspace packages that depend on the given package.
  *
  * @param project - The project containing workspace packages.
  * @param packageName - The name of the package to find dependents for.
@@ -189,14 +189,7 @@ export function findMissingUnreleasedDependents(
     },
   );
 
-  const changedDependentNames = dependentNames.filter(
-    (possibleDependentName) => {
-      return project.workspacePackages[possibleDependentName]
-        .hasChangesSinceLatestRelease;
-    },
-  );
-
-  return changedDependentNames.filter((dependentName) => {
+  return dependentNames.filter((dependentName) => {
     return !unvalidatedReleaseSpecificationPackages[dependentName];
   });
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -139,18 +139,16 @@ function createApp({
         ? majorBumps.split(',').filter(Boolean)
         : (req.query.majorBumps as string[] | undefined) || [];
 
-    const requiredDependents = [
-      ...new Set(
-        majorBumpsArray.flatMap((majorBump) =>
-          findAllWorkspacePackagesThatDependOnPackage(project, majorBump),
-        ),
+    const requiredDependents = new Set(
+      majorBumpsArray.flatMap((majorBump) =>
+        findAllWorkspacePackagesThatDependOnPackage(project, majorBump),
       ),
-    ];
+    );
 
     const pkgs = Object.values(project.workspacePackages).filter(
       (pkg) =>
         pkg.hasChangesSinceLatestRelease ||
-        requiredDependents.includes(pkg.validatedManifest.name),
+        requiredDependents.has(pkg.validatedManifest.name),
     );
 
     const packages = pkgs.map((pkg) => ({

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -10,6 +10,7 @@ import {
 } from './project.js';
 import { Package } from './package.js';
 import {
+  findAllWorkspacePackagesThatDependOnPackage,
   findMissingUnreleasedDependenciesForRelease,
   findMissingUnreleasedDependentsForBreakingChanges,
   IncrementableVersionParts,
@@ -130,15 +131,31 @@ function createApp({
   app.use(express.static(UI_BUILD_DIR));
   app.use(express.json());
 
-  app.get('/api/packages', (_req, res) => {
+  app.get('/api/packages', (req, res) => {
+    const { majorBumps } = req.query;
+
+    const majorBumpsArray =
+      typeof majorBumps === 'string'
+        ? majorBumps.split(',').filter(Boolean)
+        : (req.query.majorBumps as string[] | undefined) || [];
+
+    const requiredDependents = [
+      ...new Set(
+        majorBumpsArray.flatMap((majorBump) =>
+          findAllWorkspacePackagesThatDependOnPackage(project, majorBump),
+        ),
+      ),
+    ];
+
     const pkgs = Object.values(project.workspacePackages).filter(
-      (pkg) => pkg.hasChangesSinceLatestRelease,
+      (pkg) =>
+        pkg.hasChangesSinceLatestRelease ||
+        requiredDependents.includes(pkg.validatedManifest.name),
     );
 
     const packages = pkgs.map((pkg) => ({
       name: pkg.validatedManifest.name,
       version: pkg.validatedManifest.version.version,
-      location: pkg.directoryPath,
     }));
 
     res.json(packages);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -276,11 +276,11 @@ function App() {
   };
 
   const handleBulkAction = (action: ReleaseType) => {
-    const newReleaseSelections = { ...selections };
+    const newSelections = { ...selections };
     selectedPackages.forEach((packageName) => {
-      newReleaseSelections[packageName] = action;
+      newSelections[packageName] = action;
     });
-    setSelections(newReleaseSelections);
+    setSelections(newSelections);
     setSelectedPackages(new Set());
     setShowCheckboxes(true);
   };

--- a/src/ui/PackageItem.tsx
+++ b/src/ui/PackageItem.tsx
@@ -6,7 +6,7 @@ import { Package, ReleaseType } from './types.js';
 
 type PackageItemProps = {
   pkg: Package;
-  releaseSelections: Record<string, string>;
+  selections: Record<string, string>;
   versionErrors: Record<string, string>;
   packageDependencyErrors: Record<
     string,
@@ -22,16 +22,14 @@ type PackageItemProps = {
   onSelectionChange: (packageName: string, value: ReleaseType | '') => void;
   onCustomVersionChange: (packageName: string, version: string) => void;
   onFetchChangelog: (packageName: string) => Promise<void>;
-  setReleaseSelections: React.Dispatch<
-    React.SetStateAction<Record<string, string>>
-  >;
+  setSelections: React.Dispatch<React.SetStateAction<Record<string, string>>>;
   setChangelogs: React.Dispatch<React.SetStateAction<Record<string, string>>>;
   onToggleSelect: () => void;
 };
 
 export function PackageItem({
   pkg,
-  releaseSelections,
+  selections,
   versionErrors,
   packageDependencyErrors,
   loadingChangelogs,
@@ -41,7 +39,7 @@ export function PackageItem({
   onSelectionChange,
   onCustomVersionChange,
   onFetchChangelog,
-  setReleaseSelections,
+  setSelections,
   setChangelogs,
   onToggleSelect,
 }: PackageItemProps) {
@@ -50,8 +48,7 @@ export function PackageItem({
       key={pkg.name}
       id={`package-${pkg.name}`}
       className={`border p-4 rounded-lg ${
-        releaseSelections[pkg.name] &&
-        releaseSelections[pkg.name] !== 'intentionally-skip'
+        selections[pkg.name] && selections[pkg.name] !== 'intentionally-skip'
           ? 'border-2'
           : 'border-gray-200'
       } ${
@@ -79,19 +76,17 @@ export function PackageItem({
           <div className="flex items-center justify-between">
             <div>
               <p className="text-gray-600">Current version: {pkg.version}</p>
-              {releaseSelections[pkg.name] &&
-                releaseSelections[pkg.name] !== 'intentionally-skip' &&
-                releaseSelections[pkg.name] !== 'custom' &&
+              {selections[pkg.name] &&
+                selections[pkg.name] !== 'intentionally-skip' &&
+                selections[pkg.name] !== 'custom' &&
                 !versionErrors[pkg.name] && (
                   <p className="text-yellow-700">
                     New version:{' '}
-                    {!['patch', 'minor', 'major'].includes(
-                      releaseSelections[pkg.name],
-                    )
-                      ? releaseSelections[pkg.name]
+                    {!['patch', 'minor', 'major'].includes(selections[pkg.name])
+                      ? selections[pkg.name]
                       : new SemVer(pkg.version)
                           .inc(
-                            releaseSelections[pkg.name] as Exclude<
+                            selections[pkg.name] as Exclude<
                               ReleaseType,
                               'intentionally-skip' | 'custom' | string
                             >,
@@ -107,7 +102,7 @@ export function PackageItem({
             </div>
             <VersionSelector
               packageName={pkg.name}
-              selection={releaseSelections[pkg.name]}
+              selection={selections[pkg.name]}
               onSelectionChange={onSelectionChange}
               onCustomVersionChange={onCustomVersionChange}
               onFetchChangelog={onFetchChangelog}
@@ -125,7 +120,7 @@ export function PackageItem({
               <DependencyErrorSection
                 title="Missing Dependencies"
                 items={packageDependencyErrors[pkg.name].missingDependencies}
-                setSelections={setReleaseSelections}
+                setSelections={setSelections}
                 description={`The following packages are dependencies or peer dependencies of ${pkg.name}. Because they may have introduced new changes that ${pkg.name} is now using, you need to verify whether to include them in the release.
 
 To do this, look at the change history for each package and compare it with the change history for ${pkg.name}. If ${pkg.name} uses any new changes from a package, then you need to include it by bumping its version. If you have confirmed that the changes to a package do not affect ${pkg.name}, you may omit it from the release by choosing "Skip" instead.`}
@@ -139,7 +134,7 @@ To do this, look at the change history for each package and compare it with the 
                   items={
                     packageDependencyErrors[pkg.name].missingDependentNames
                   }
-                  setSelections={setReleaseSelections}
+                  setSelections={setSelections}
                   description={`Because ${pkg.name} is being released with a new major version, to prevent peer dependency warnings in consuming projects, all of the following packages which list ${pkg.name} as a peer dependency need to be included in the release. Please choose new versions for these packages. If for some reason you feel it is safe to omit a package you may choose "Skip".`}
                 />
               </div>

--- a/src/ui/PackageItem.tsx
+++ b/src/ui/PackageItem.tsx
@@ -6,7 +6,7 @@ import { Package, ReleaseType } from './types.js';
 
 type PackageItemProps = {
   pkg: Package;
-  selections: Record<string, string>;
+  releaseSelections: Record<string, string>;
   versionErrors: Record<string, string>;
   packageDependencyErrors: Record<
     string,
@@ -22,14 +22,16 @@ type PackageItemProps = {
   onSelectionChange: (packageName: string, value: ReleaseType | '') => void;
   onCustomVersionChange: (packageName: string, version: string) => void;
   onFetchChangelog: (packageName: string) => Promise<void>;
-  setSelections: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  setReleaseSelections: React.Dispatch<
+    React.SetStateAction<Record<string, string>>
+  >;
   setChangelogs: React.Dispatch<React.SetStateAction<Record<string, string>>>;
   onToggleSelect: () => void;
 };
 
 export function PackageItem({
   pkg,
-  selections,
+  releaseSelections,
   versionErrors,
   packageDependencyErrors,
   loadingChangelogs,
@@ -39,7 +41,7 @@ export function PackageItem({
   onSelectionChange,
   onCustomVersionChange,
   onFetchChangelog,
-  setSelections,
+  setReleaseSelections,
   setChangelogs,
   onToggleSelect,
 }: PackageItemProps) {
@@ -48,7 +50,8 @@ export function PackageItem({
       key={pkg.name}
       id={`package-${pkg.name}`}
       className={`border p-4 rounded-lg ${
-        selections[pkg.name] && selections[pkg.name] !== 'intentionally-skip'
+        releaseSelections[pkg.name] &&
+        releaseSelections[pkg.name] !== 'intentionally-skip'
           ? 'border-2'
           : 'border-gray-200'
       } ${
@@ -76,17 +79,19 @@ export function PackageItem({
           <div className="flex items-center justify-between">
             <div>
               <p className="text-gray-600">Current version: {pkg.version}</p>
-              {selections[pkg.name] &&
-                selections[pkg.name] !== 'intentionally-skip' &&
-                selections[pkg.name] !== 'custom' &&
+              {releaseSelections[pkg.name] &&
+                releaseSelections[pkg.name] !== 'intentionally-skip' &&
+                releaseSelections[pkg.name] !== 'custom' &&
                 !versionErrors[pkg.name] && (
                   <p className="text-yellow-700">
                     New version:{' '}
-                    {!['patch', 'minor', 'major'].includes(selections[pkg.name])
-                      ? selections[pkg.name]
+                    {!['patch', 'minor', 'major'].includes(
+                      releaseSelections[pkg.name],
+                    )
+                      ? releaseSelections[pkg.name]
                       : new SemVer(pkg.version)
                           .inc(
-                            selections[pkg.name] as Exclude<
+                            releaseSelections[pkg.name] as Exclude<
                               ReleaseType,
                               'intentionally-skip' | 'custom' | string
                             >,
@@ -102,7 +107,7 @@ export function PackageItem({
             </div>
             <VersionSelector
               packageName={pkg.name}
-              selection={selections[pkg.name]}
+              selection={releaseSelections[pkg.name]}
               onSelectionChange={onSelectionChange}
               onCustomVersionChange={onCustomVersionChange}
               onFetchChangelog={onFetchChangelog}
@@ -120,7 +125,7 @@ export function PackageItem({
               <DependencyErrorSection
                 title="Missing Dependencies"
                 items={packageDependencyErrors[pkg.name].missingDependencies}
-                setSelections={setSelections}
+                setSelections={setReleaseSelections}
                 description={`The following packages are dependencies or peer dependencies of ${pkg.name}. Because they may have introduced new changes that ${pkg.name} is now using, you need to verify whether to include them in the release.
 
 To do this, look at the change history for each package and compare it with the change history for ${pkg.name}. If ${pkg.name} uses any new changes from a package, then you need to include it by bumping its version. If you have confirmed that the changes to a package do not affect ${pkg.name}, you may omit it from the release by choosing "Skip" instead.`}
@@ -134,7 +139,7 @@ To do this, look at the change history for each package and compare it with the 
                   items={
                     packageDependencyErrors[pkg.name].missingDependentNames
                   }
-                  setSelections={setSelections}
+                  setSelections={setReleaseSelections}
                   description={`Because ${pkg.name} is being released with a new major version, to prevent peer dependency warnings in consuming projects, all of the following packages which list ${pkg.name} as a peer dependency need to be included in the release. Please choose new versions for these packages. If for some reason you feel it is safe to omit a package you may choose "Skip".`}
                 />
               </div>


### PR DESCRIPTION
## Description
This PR fixes an important visibility issue in our release process where packages that should be considered for release due to peer dependency updates weren't being surfaced to users during the release workflow if they had no changes since their latest release.

### Technical Details
- Modified `findMissingUnreleasedDependents` to consider all dependent packages, not just those with changes since their latest release
- This ensures that all dependencies are properly validated during the release process, regardless of their change status

Fixes https://github.com/MetaMask/create-release-branch/issues/164