### PR TITLE
fix: gracefully handle browser open failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Improved error handling when opening browser fails due to System Events permissions or non-standard browser configurations ([#178](https://github.com/MetaMask/create-release-branch/pull/178))
+  - Now provides clear manual URL instructions instead of failing with osascript errors
+  - Handles both cases: when terminal lacks System Events permissions and when using alternative browsers like Brave
 
 ## [4.1.1]
 ### Fixed

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,6 @@ export async function main({
     );
 
     if (interactive) {
-      stdout.write(`Starting UI on port ${port}...\n`);
       await startUI({
         project,
         releaseType,

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,7 +1,7 @@
 import type { WriteStream } from 'fs';
 import { join } from 'path';
 import express from 'express';
-import open, { apps } from 'open';
+import open from 'open';
 
 import {
   restoreChangelogsForSkippedPackages,
@@ -86,8 +86,18 @@ export async function startUI({
 
   const server = app.listen(port, async () => {
     const url = `http://localhost:${port}`;
-    stdout.write(`UI server running at ${url}\n`);
-    open(url, { app: { name: apps.browser } });
+
+    try {
+      stdout.write(`\nAttempting to open UI in browser...`);
+      await open(url);
+      stdout.write(`\nUI server running at ${url}\n`);
+    } catch (error) {
+      stderr.write(`\n---------------------------------------------------\n`);
+      stderr.write(`Error automatically opening browser: ${error}\n`);
+      stderr.write(`Please open the following URL manually:\n`);
+      stderr.write(`${url}\n`);
+      stderr.write(`---------------------------------------------------\n\n`);
+    }
   });
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Description
This PR improves the error handling when automatically opening the browser fails. Several users have reported issues with the `create-release-branch` tool failing when their terminal application lacks sufficient privileges for System Events or when using non-standard browsers like Brave.

Instead of failing with an unclear osascript error, the tool now:
- Attempts to open the browser gracefully
- Falls back to displaying clear manual instructions if automatic opening fails
- Continues running the server regardless of browser open status

## Testing Instructions

### Prerequisites
- macOS system
- Terminal application (Terminal.app, iTerm2, VS Code integrated terminal, etc.)

### Test Case 1: System Events Permission Disabled
1. First, test current behavior on main:
   ```bash
   git checkout main
   yarn build
   // use package locally (eg: from Core repo)
   yarn && yarn create-release-branch -i
   ```
   - Note that it fails with osascript error if permissions are not granted

2. Disable System Events permission:
   - Open System Settings > Privacy & Security > Automation
   - Find your terminal application
   - Disable "System Events" permission

3. Test the fix:
   ```bash
   git checkout fix/handle-macos-browser-open-permissions
   yarn build
   // use package locally (eg: from Core repo)
   yarn && yarn create-release-branch -i
   ```
   - Verify you see a clear message with the URL to open manually
   - Verify the server continues running
   - Verify you can copy/paste the URL and access the UI

### Test Case 2: Non-standard Browser (Brave)
1. Set Brave as your default browser

2. Test current behavior on main:
   ```bash
   git checkout main
   yarn build
   // use package locally (eg: from Core repo)
   yarn && yarn create-release-branch -i
   ```
   - Note any errors or unexpected behavior

3. Test the fix:
   ```bash
   git checkout fix/handle-macos-browser-open-permissions
   yarn build
   // use package locally (eg: from Core repo)
   yarn && yarn create-release-branch -i
   ```
   - Verify you see either:
     a) Browser opens successfully in Brave, or
     b) Clear instructions to open the URL manually
   - Verify the server continues running
   - Verify you can access the UI by manually opening the URL