### PR TITLE
Test preview workflow

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -5,78 +5,10 @@ on:
     types: created
 
 jobs:
-  is-fork-pull-request:
-    name: Determine whether this issue comment was on a pull request from a fork
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '@metamaskbot publish-preview') }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Determine whether this PR is from a fork
-        id: is-fork
-        run: echo "IS_FORK=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${PR_NUMBER}" )" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-
-  react-to-comment:
-    name: React to the comment
-    needs: is-fork-pull-request
-    # This ensures we don't publish on forks. We can't trust forks with this token.
-    if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: React to the comment
-        run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
-            -f content='+1'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMMENT_ID: ${{ github.event.comment.id }}
-          REPO: ${{ github.repository }}
-
   publish-preview:
-    name: Publish build preview
-    needs: react-to-comment
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check out pull request
-        run: gh pr checkout "${PR_NUMBER}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-      - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
-        with:
-          is-high-risk-environment: true
-      - name: Get commit SHA
-        id: commit-sha
-        run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-      - run: ./scripts/prepare-preview-builds.sh @metamask-previews ${{ steps.commit-sha.outputs.COMMIT_SHA }}
-      - run: yarn build
-      - name: Publish preview build
-        run: yarn npm publish --tag preview
-        env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.PUBLISH_PREVIEW_NPM_TOKEN }}
-      - name: Post build preview in comment
-        run: ./scripts/generate-preview-build-message.sh | gh pr comment "${PR_NUMBER}" --body-file -
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMMIT_SHA: ${{ steps.commit-sha.outputs.COMMIT_SHA }}
-          PR_NUMBER: ${{ github.event.issue.number }}
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '@metamaskbot publish-preview') }}
+    uses: MetaMask/github-tools/.github/workflows/publish-preview.yml@prepare-preview-builds-action
+    with:
+      is-monorepo: false
+    secrets:
+      PUBLISH_PREVIEW_NPM_TOKEN: ${{ secrets.PUBLISH_PREVIEW_NPM_TOKEN }}

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -10,5 +10,6 @@ jobs:
     uses: MetaMask/github-tools/.github/workflows/publish-preview.yml@prepare-preview-builds-action
     with:
       is-monorepo: false
+      dry-run: true
     secrets:
       PUBLISH_PREVIEW_NPM_TOKEN: ${{ secrets.PUBLISH_PREVIEW_NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -116,3 +116,4 @@ If you make more changes to your pull request and want to create a new preview b
 1. Post another `@metamaskbot` comment on the pull request and wait for the response.
 2. Update the version of the preview build in your project's `package.json`. Make sure to re-run `yarn install`!
 
+

--- a/README.md
+++ b/README.md
@@ -115,5 +115,3 @@ If you make more changes to your pull request and want to create a new preview b
 
 1. Post another `@metamaskbot` comment on the pull request and wait for the response.
 2. Update the version of the preview build in your project's `package.json`. Make sure to re-run `yarn install`!
-
-

--- a/README.md
+++ b/README.md
@@ -115,3 +115,4 @@ If you make more changes to your pull request and want to create a new preview b
 
 1. Post another `@metamaskbot` comment on the pull request and wait for the response.
 2. Update the version of the preview build in your project's `package.json`. Make sure to re-run `yarn install`!
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the preview publish GitHub Actions workflow to delegate logic to an external reusable workflow, which can affect release/CI behavior and introduces dependency on `MetaMask/github-tools` (not pinned to a SHA).
> 
> **Overview**
> **Simplifies the preview publish pipeline** by replacing the inline `publish-preview` workflow jobs (fork/PR checks, comment reaction, checkout/build/publish, and PR comment posting) with a single reusable workflow call to `MetaMask/github-tools/.github/workflows/publish-preview.yml@prepare-preview-builds-action`.
> 
> The workflow still triggers from `@metamaskbot publish-preview` issue comments, and now passes `is-monorepo: false`, `dry-run: true`, and forwards `PUBLISH_PREVIEW_NPM_TOKEN` as a secret.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f922fe8dbb9cf1fdfa2d149900fb7576723cd525. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->