### PR TITLE
feat: Add option to use Oxfmt for formatting changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@metamask/action-utils": "^1.0.0",
-    "@metamask/auto-changelog": "^4.0.0",
+    "@metamask/auto-changelog": "^6.1.0",
     "@metamask/utils": "^9.0.0",
     "debug": "^4.3.4",
     "execa": "^8.0.1",
@@ -93,7 +93,16 @@
     "vite": "^6.2.0"
   },
   "peerDependencies": {
+    "oxfmt": "^0.45.0",
     "prettier": ">=3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "oxfmt": {
+      "optional": true
+    },
+    "prettier": {
+      "optional": true
+    }
   },
   "packageManager": "yarn@3.2.1",
   "engines": {

--- a/src/command-line-arguments.ts
+++ b/src/command-line-arguments.ts
@@ -9,6 +9,7 @@ export type CommandLineArguments = {
   defaultBranch: string;
   interactive: boolean;
   port: number;
+  formatter: string;
 };
 
 /**
@@ -65,6 +66,11 @@ export async function readCommandLineArguments(
         'Port to run the interactive web UI server (only used with --interactive)',
       type: 'number',
       default: 3000,
+    })
+    .option('formatter', {
+      describe: 'The formatter to use for changelog formatting.',
+      choices: ['oxfmt', 'prettier'],
+      default: 'prettier',
     })
     .help()
     .strict()

--- a/src/initial-parameters.test.ts
+++ b/src/initial-parameters.test.ts
@@ -38,6 +38,7 @@ describe('initial-parameters', () => {
           defaultBranch: 'main',
           interactive: false,
           port: 3000,
+          formatter: 'prettier',
         });
       jest
         .spyOn(envModule, 'getEnvironmentVariables')
@@ -60,6 +61,7 @@ describe('initial-parameters', () => {
         defaultBranch: 'main',
         interactive: false,
         port: 3000,
+        formatter: 'prettier',
       });
     });
 
@@ -78,6 +80,7 @@ describe('initial-parameters', () => {
           defaultBranch: 'main',
           interactive: false,
           port: 3000,
+          formatter: 'prettier',
         });
       jest
         .spyOn(envModule, 'getEnvironmentVariables')
@@ -110,6 +113,7 @@ describe('initial-parameters', () => {
           defaultBranch: 'main',
           interactive: false,
           port: 3000,
+          formatter: 'prettier',
         });
       jest
         .spyOn(envModule, 'getEnvironmentVariables')
@@ -142,6 +146,7 @@ describe('initial-parameters', () => {
           defaultBranch: 'main',
           interactive: false,
           port: 3000,
+          formatter: 'prettier',
         });
       jest
         .spyOn(envModule, 'getEnvironmentVariables')
@@ -174,6 +179,7 @@ describe('initial-parameters', () => {
           defaultBranch: 'main',
           interactive: false,
           port: 3000,
+          formatter: 'prettier',
         });
       jest
         .spyOn(envModule, 'getEnvironmentVariables')
@@ -204,6 +210,7 @@ describe('initial-parameters', () => {
           defaultBranch: 'main',
           interactive: false,
           port: 3000,
+          formatter: 'prettier',
         });
       jest
         .spyOn(envModule, 'getEnvironmentVariables')
@@ -234,6 +241,7 @@ describe('initial-parameters', () => {
           defaultBranch: 'main',
           interactive: false,
           port: 3000,
+          formatter: 'prettier',
         });
       jest
         .spyOn(envModule, 'getEnvironmentVariables')
@@ -264,6 +272,7 @@ describe('initial-parameters', () => {
           defaultBranch: 'main',
           interactive: false,
           port: 3000,
+          formatter: 'prettier',
         });
       jest
         .spyOn(envModule, 'getEnvironmentVariables')

--- a/src/initial-parameters.ts
+++ b/src/initial-parameters.ts
@@ -15,6 +15,11 @@ import { readProject, Project } from './project.js';
  */
 export type ReleaseType = 'ordinary' | 'backport';
 
+/**
+ * The name of the formatter to use for formatting the changelog.
+ */
+export type Formatter = 'oxfmt' | 'prettier';
+
 type InitialParameters = {
   project: Project;
   tempDirectoryPath: string;
@@ -23,6 +28,7 @@ type InitialParameters = {
   defaultBranch: string;
   interactive: boolean;
   port: number;
+  formatter: Formatter;
 };
 
 /**
@@ -65,5 +71,6 @@ export async function determineInitialParameters({
     releaseType: args.backport ? 'backport' : 'ordinary',
     interactive: args.interactive,
     port: args.port,
+    formatter: args.formatter as Formatter,
   };
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -32,6 +32,7 @@ describe('main', () => {
         releaseType: 'backport',
         interactive: false,
         port: 3000,
+        formatter: 'prettier',
       });
     const followMonorepoWorkflowSpy = jest
       .spyOn(monorepoWorkflowOperations, 'followMonorepoWorkflow')
@@ -69,6 +70,7 @@ describe('main', () => {
         releaseType: 'backport',
         interactive: true,
         port: 3000,
+        formatter: 'prettier',
       });
     const startUISpy = jest.spyOn(ui, 'startUI').mockResolvedValue();
 
@@ -103,6 +105,7 @@ describe('main', () => {
         releaseType: 'backport',
         interactive: false,
         port: 3000,
+        formatter: 'prettier',
       });
     const followMonorepoWorkflowSpy = jest
       .spyOn(monorepoWorkflowOperations, 'followMonorepoWorkflow')

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -51,6 +51,7 @@ describe('main', () => {
       firstRemovingExistingReleaseSpecification: true,
       releaseType: 'backport',
       defaultBranch: 'main',
+      formatter: 'prettier',
       stdout,
       stderr,
     });
@@ -86,6 +87,7 @@ describe('main', () => {
       releaseType: 'backport',
       defaultBranch: 'main',
       port: 3000,
+      formatter: 'prettier',
       stdout,
       stderr,
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ export async function main({
     defaultBranch,
     interactive,
     port,
+    formatter,
   } = await determineInitialParameters({ argv, cwd, stderr });
 
   if (project.isMonorepo) {
@@ -47,6 +48,7 @@ export async function main({
         releaseType,
         defaultBranch,
         port,
+        formatter,
         stdout,
         stderr,
       });
@@ -57,6 +59,7 @@ export async function main({
         firstRemovingExistingReleaseSpecification: reset,
         releaseType,
         defaultBranch,
+        formatter,
         stdout,
         stderr,
       });

--- a/src/monorepo-workflow-operations.test.ts
+++ b/src/monorepo-workflow-operations.test.ts
@@ -14,6 +14,7 @@ import type { ReleasePlan } from './release-plan.js';
 import * as repoModule from './repo.js';
 import * as yarnCommands from './yarn-commands.js';
 import * as workflowOperations from './workflow-operations.js';
+import { Formatter } from './initial-parameters.js';
 
 jest.mock('./editor');
 jest.mock('./release-plan');
@@ -157,6 +158,8 @@ function buildMockEditor({
  * `executeReleasePlan` will throw.
  * @param args.releaseVersion - The new version that the release plan will
  * contain.
+ * @param args.formatter - The formatter that will be passed to
+ * `executeReleasePlan`.
  * @returns Mock functions and other data that can be used in tests to make
  * assertions.
  */
@@ -169,6 +172,7 @@ async function setupFollowMonorepoWorkflow({
   errorUponPlanningRelease,
   errorUponExecutingReleasePlan,
   releaseVersion = '1.0.0',
+  formatter = 'prettier',
 }: {
   sandbox: Sandbox;
   doesReleaseSpecFileExist: boolean;
@@ -178,6 +182,7 @@ async function setupFollowMonorepoWorkflow({
   errorUponPlanningRelease?: Error;
   errorUponExecutingReleasePlan?: Error;
   releaseVersion?: string;
+  formatter?: Formatter;
 }) {
   const {
     determineEditorSpy,
@@ -250,11 +255,11 @@ async function setupFollowMonorepoWorkflow({
 
   if (errorUponExecutingReleasePlan) {
     when(executeReleasePlanSpy)
-      .calledWith(project, releasePlan, stderr)
+      .calledWith(project, releasePlan, formatter, stderr)
       .mockRejectedValue(errorUponExecutingReleasePlan);
   } else {
     when(executeReleasePlanSpy)
-      .calledWith(project, releasePlan, stderr)
+      .calledWith(project, releasePlan, formatter, stderr)
       .mockResolvedValue(undefined);
   }
 
@@ -272,6 +277,7 @@ async function setupFollowMonorepoWorkflow({
   return {
     project,
     projectDirectoryPath,
+    formatter,
     stdout,
     stderr,
     generateReleaseSpecificationTemplateForMonorepoSpy,
@@ -295,7 +301,7 @@ describe('monorepo-workflow-operations', () => {
     describe('when firstRemovingExistingReleaseSpecification is false, the release spec file does not already exist, and an editor is available', () => {
       it('should call createReleaseBranch with the correct arguments if given releaseType: "ordinary"', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, createReleaseBranchSpy } =
+          const { project, stdout, stderr, createReleaseBranchSpy, formatter } =
             await setupFollowMonorepoWorkflow({
               sandbox,
               doesReleaseSpecFileExist: false,
@@ -308,6 +314,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -321,7 +328,7 @@ describe('monorepo-workflow-operations', () => {
 
       it('should call createReleaseBranch with the correct arguments if given releaseType: "backport"', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, createReleaseBranchSpy } =
+          const { project, stdout, stderr, createReleaseBranchSpy, formatter } =
             await setupFollowMonorepoWorkflow({
               sandbox,
               doesReleaseSpecFileExist: false,
@@ -334,6 +341,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'backport',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -353,6 +361,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             releaseSpecification,
             planReleaseSpy,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: false,
@@ -365,6 +374,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -385,6 +395,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             releaseSpecification,
             planReleaseSpy,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: false,
@@ -397,6 +408,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'backport',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -422,6 +434,7 @@ describe('monorepo-workflow-operations', () => {
             fixConstraintsSpy,
             updateYarnLockfileSpy,
             deduplicateDependenciesSpy,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             releaseVersion,
@@ -440,6 +453,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -488,6 +502,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -515,6 +530,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             executeReleasePlanSpy,
             releasePlan,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: false,
@@ -528,6 +544,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -535,6 +552,7 @@ describe('monorepo-workflow-operations', () => {
           expect(executeReleasePlanSpy).toHaveBeenCalledWith(
             project,
             releasePlan,
+            formatter,
             stderr,
           );
         });
@@ -548,6 +566,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             commitAllChangesSpy,
             projectDirectoryPath,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: false,
@@ -561,6 +580,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -579,12 +599,17 @@ describe('monorepo-workflow-operations', () => {
 
       it('removes the release spec file after editing, validating, and executing the release spec', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: false,
-              isEditorAvailable: true,
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: false,
+            isEditorAvailable: true,
+          });
 
           await followMonorepoWorkflow({
             project,
@@ -592,6 +617,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -602,7 +628,7 @@ describe('monorepo-workflow-operations', () => {
 
       it('does not attempt to execute the release spec if it was not successfully edited', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, executeReleasePlanSpy } =
+          const { project, stdout, stderr, executeReleasePlanSpy, formatter } =
             await setupFollowMonorepoWorkflow({
               sandbox,
               doesReleaseSpecFileExist: false,
@@ -617,6 +643,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: false,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -634,6 +661,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             commitAllChangesSpy,
             projectDirectoryPath,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: false,
@@ -648,6 +676,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: false,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -666,13 +695,18 @@ describe('monorepo-workflow-operations', () => {
 
       it('removes the release spec file even if it was not successfully edited', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: false,
-              isEditorAvailable: true,
-              errorUponEditingReleaseSpec: new Error('oops'),
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: false,
+            isEditorAvailable: true,
+            errorUponEditingReleaseSpec: new Error('oops'),
+          });
 
           await expect(
             followMonorepoWorkflow({
@@ -681,6 +715,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: false,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -692,14 +727,13 @@ describe('monorepo-workflow-operations', () => {
 
       it('throws an error produced while editing the release spec', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr } = await setupFollowMonorepoWorkflow(
-            {
+          const { project, stdout, stderr, formatter } =
+            await setupFollowMonorepoWorkflow({
               sandbox,
               doesReleaseSpecFileExist: false,
               isEditorAvailable: true,
               errorUponEditingReleaseSpec: new Error('oops'),
-            },
-          );
+            });
 
           await expect(
             followMonorepoWorkflow({
@@ -708,6 +742,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: false,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -718,13 +753,18 @@ describe('monorepo-workflow-operations', () => {
       it('does not remove the generated release spec file if it was successfully edited but an error is thrown while validating the release spec', async () => {
         await withSandbox(async (sandbox) => {
           const errorUponValidatingReleaseSpec = new Error('oops');
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: false,
-              isEditorAvailable: true,
-              errorUponValidatingReleaseSpec,
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: false,
+            isEditorAvailable: true,
+            errorUponValidatingReleaseSpec,
+          });
 
           await expect(
             followMonorepoWorkflow({
@@ -733,6 +773,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: false,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -745,14 +786,19 @@ describe('monorepo-workflow-operations', () => {
       it('does not remove the generated release spec file if it was successfully edited but an error is thrown while planning the release', async () => {
         await withSandbox(async (sandbox) => {
           const errorUponPlanningRelease = new Error('oops');
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: false,
-              isEditorAvailable: true,
-              errorUponPlanningRelease,
-              releaseVersion: '2.0.0',
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: false,
+            isEditorAvailable: true,
+            errorUponPlanningRelease,
+            releaseVersion: '2.0.0',
+          });
 
           await expect(
             followMonorepoWorkflow({
@@ -761,6 +807,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: false,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -773,14 +820,19 @@ describe('monorepo-workflow-operations', () => {
       it('does not remove the generated release spec file if it was successfully edited but an error is thrown while executing the release plan', async () => {
         await withSandbox(async (sandbox) => {
           const errorUponExecutingReleasePlan = new Error('oops');
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: false,
-              isEditorAvailable: true,
-              errorUponExecutingReleasePlan,
-              releaseVersion: '2.0.0',
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: false,
+            isEditorAvailable: true,
+            errorUponExecutingReleasePlan,
+            releaseVersion: '2.0.0',
+          });
 
           await expect(
             followMonorepoWorkflow({
@@ -789,6 +841,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: false,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -802,7 +855,7 @@ describe('monorepo-workflow-operations', () => {
     describe('when firstRemovingExistingReleaseSpecification is false, the release spec file does not already exist, and an editor is not available', () => {
       it('does not attempt to execute the edited release spec', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, executeReleasePlanSpy } =
+          const { project, stdout, stderr, executeReleasePlanSpy, formatter } =
             await setupFollowMonorepoWorkflow({
               sandbox,
               doesReleaseSpecFileExist: false,
@@ -815,6 +868,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -831,6 +885,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             commitAllChangesSpy,
             projectDirectoryPath,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: false,
@@ -843,6 +898,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -856,33 +912,7 @@ describe('monorepo-workflow-operations', () => {
 
       it('prints a message', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr } = await setupFollowMonorepoWorkflow(
-            {
-              sandbox,
-              doesReleaseSpecFileExist: false,
-              isEditorAvailable: false,
-            },
-          );
-
-          await followMonorepoWorkflow({
-            project,
-            tempDirectoryPath: sandbox.directoryPath,
-            firstRemovingExistingReleaseSpecification: false,
-            releaseType: 'ordinary',
-            defaultBranch: 'main',
-            stdout,
-            stderr,
-          });
-
-          expect(stdout.data()[0]).toMatch(
-            /^A template has been generated that specifies this release/u,
-          );
-        });
-      });
-
-      it('does not remove the generated release spec file', async () => {
-        await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, releaseSpecificationPath } =
+          const { project, stdout, stderr, formatter } =
             await setupFollowMonorepoWorkflow({
               sandbox,
               doesReleaseSpecFileExist: false,
@@ -895,6 +925,38 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
+            stdout,
+            stderr,
+          });
+
+          expect(stdout.data()[0]).toMatch(
+            /^A template has been generated that specifies this release/u,
+          );
+        });
+      });
+
+      it('does not remove the generated release spec file', async () => {
+        await withSandbox(async (sandbox) => {
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: false,
+            isEditorAvailable: false,
+          });
+
+          await followMonorepoWorkflow({
+            project,
+            tempDirectoryPath: sandbox.directoryPath,
+            firstRemovingExistingReleaseSpecification: false,
+            releaseType: 'ordinary',
+            defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -912,6 +974,7 @@ describe('monorepo-workflow-operations', () => {
             stdout,
             stderr,
             waitForUserToEditReleaseSpecificationSpy,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: true,
@@ -923,6 +986,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -941,6 +1005,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             releaseSpecification,
             planReleaseSpy,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: true,
@@ -952,6 +1017,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -972,6 +1038,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             releaseSpecification,
             planReleaseSpy,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: true,
@@ -983,6 +1050,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'backport',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1003,6 +1071,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             executeReleasePlanSpy,
             releasePlan,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: true,
@@ -1015,6 +1084,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1022,6 +1092,7 @@ describe('monorepo-workflow-operations', () => {
           expect(executeReleasePlanSpy).toHaveBeenCalledWith(
             project,
             releasePlan,
+            formatter,
             stderr,
           );
         });
@@ -1035,6 +1106,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             commitAllChangesSpy,
             projectDirectoryPath,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: true,
@@ -1047,6 +1119,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1065,11 +1138,16 @@ describe('monorepo-workflow-operations', () => {
 
       it('removes the release spec file after validating and executing the release spec', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: true,
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: true,
+          });
 
           await followMonorepoWorkflow({
             project,
@@ -1077,6 +1155,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: false,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1088,12 +1167,17 @@ describe('monorepo-workflow-operations', () => {
       it('does not remove the generated release spec file if an error is thrown while validating the release spec', async () => {
         await withSandbox(async (sandbox) => {
           const errorUponValidatingReleaseSpec = new Error('oops');
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: true,
-              errorUponValidatingReleaseSpec,
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: true,
+            errorUponValidatingReleaseSpec,
+          });
 
           await expect(
             followMonorepoWorkflow({
@@ -1102,6 +1186,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: false,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -1114,13 +1199,18 @@ describe('monorepo-workflow-operations', () => {
       it('does not remove the generated release spec file if an error is thrown while planning the release', async () => {
         await withSandbox(async (sandbox) => {
           const errorUponPlanningRelease = new Error('oops');
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: true,
-              errorUponPlanningRelease,
-              releaseVersion: '2.0.0',
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: true,
+            errorUponPlanningRelease,
+            releaseVersion: '2.0.0',
+          });
 
           await expect(
             followMonorepoWorkflow({
@@ -1129,6 +1219,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: false,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -1141,13 +1232,18 @@ describe('monorepo-workflow-operations', () => {
       it('does not remove the generated release spec file if an error is thrown while executing the release plan', async () => {
         await withSandbox(async (sandbox) => {
           const errorUponExecutingReleasePlan = new Error('oops');
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: true,
-              errorUponExecutingReleasePlan,
-              releaseVersion: '2.0.0',
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: true,
+            errorUponExecutingReleasePlan,
+            releaseVersion: '2.0.0',
+          });
 
           await expect(
             followMonorepoWorkflow({
@@ -1156,6 +1252,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: false,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -1175,6 +1272,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             releaseSpecification,
             planReleaseSpy,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: false,
@@ -1187,6 +1285,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1207,6 +1306,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             releaseSpecification,
             planReleaseSpy,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: false,
@@ -1219,6 +1319,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'backport',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1239,6 +1340,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             executeReleasePlanSpy,
             releasePlan,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: false,
@@ -1252,6 +1354,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1259,6 +1362,7 @@ describe('monorepo-workflow-operations', () => {
           expect(executeReleasePlanSpy).toHaveBeenCalledWith(
             project,
             releasePlan,
+            formatter,
             stderr,
           );
         });
@@ -1272,6 +1376,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             commitAllChangesSpy,
             projectDirectoryPath,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: false,
@@ -1285,6 +1390,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1303,12 +1409,17 @@ describe('monorepo-workflow-operations', () => {
 
       it('removes the release spec file after editing, validating, and executing the release spec', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: false,
-              isEditorAvailable: true,
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: false,
+            isEditorAvailable: true,
+          });
 
           await followMonorepoWorkflow({
             project,
@@ -1316,6 +1427,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1326,7 +1438,7 @@ describe('monorepo-workflow-operations', () => {
 
       it('does not attempt to execute the release spec if it was not successfully edited', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, executeReleasePlanSpy } =
+          const { project, stdout, stderr, executeReleasePlanSpy, formatter } =
             await setupFollowMonorepoWorkflow({
               sandbox,
               doesReleaseSpecFileExist: false,
@@ -1341,6 +1453,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: true,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -1358,6 +1471,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             commitAllChangesSpy,
             projectDirectoryPath,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: false,
@@ -1372,6 +1486,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: true,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -1386,13 +1501,18 @@ describe('monorepo-workflow-operations', () => {
 
       it('removes the release spec file even if it was not successfully edited', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: false,
-              isEditorAvailable: true,
-              errorUponEditingReleaseSpec: new Error('oops'),
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: false,
+            isEditorAvailable: true,
+            errorUponEditingReleaseSpec: new Error('oops'),
+          });
 
           await expect(
             followMonorepoWorkflow({
@@ -1401,6 +1521,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: true,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -1412,14 +1533,13 @@ describe('monorepo-workflow-operations', () => {
 
       it('throws an error produced while editing the release spec', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr } = await setupFollowMonorepoWorkflow(
-            {
+          const { project, stdout, stderr, formatter } =
+            await setupFollowMonorepoWorkflow({
               sandbox,
               doesReleaseSpecFileExist: false,
               isEditorAvailable: true,
               errorUponEditingReleaseSpec: new Error('oops'),
-            },
-          );
+            });
 
           await expect(
             followMonorepoWorkflow({
@@ -1428,6 +1548,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: true,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -1438,13 +1559,18 @@ describe('monorepo-workflow-operations', () => {
       it('does not remove the generated release spec file if it was successfully edited but an error is thrown while validating the release spec', async () => {
         await withSandbox(async (sandbox) => {
           const errorUponValidatingReleaseSpec = new Error('oops');
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: false,
-              isEditorAvailable: true,
-              errorUponValidatingReleaseSpec,
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: false,
+            isEditorAvailable: true,
+            errorUponValidatingReleaseSpec,
+          });
 
           await expect(
             followMonorepoWorkflow({
@@ -1453,6 +1579,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: true,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -1465,14 +1592,19 @@ describe('monorepo-workflow-operations', () => {
       it('does not remove the generated release spec file if it was successfully edited but an error is thrown while planning the release', async () => {
         await withSandbox(async (sandbox) => {
           const errorUponPlanningRelease = new Error('oops');
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: false,
-              isEditorAvailable: true,
-              errorUponPlanningRelease,
-              releaseVersion: '2.0.0',
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: false,
+            isEditorAvailable: true,
+            errorUponPlanningRelease,
+            releaseVersion: '2.0.0',
+          });
 
           await expect(
             followMonorepoWorkflow({
@@ -1481,6 +1613,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: true,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -1493,14 +1626,19 @@ describe('monorepo-workflow-operations', () => {
       it('does not remove the generated release spec file if it was successfully edited but an error is thrown while executing the release plan', async () => {
         await withSandbox(async (sandbox) => {
           const errorUponExecutingReleasePlan = new Error('oops');
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: false,
-              isEditorAvailable: true,
-              errorUponExecutingReleasePlan,
-              releaseVersion: '2.0.0',
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: false,
+            isEditorAvailable: true,
+            errorUponExecutingReleasePlan,
+            releaseVersion: '2.0.0',
+          });
 
           await expect(
             followMonorepoWorkflow({
@@ -1509,6 +1647,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: true,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -1522,7 +1661,7 @@ describe('monorepo-workflow-operations', () => {
     describe('when firstRemovingExistingReleaseSpecification is true, the release spec file does not already exist, and an editor is not available', () => {
       it('does not attempt to execute the edited release spec', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, executeReleasePlanSpy } =
+          const { project, stdout, stderr, executeReleasePlanSpy, formatter } =
             await setupFollowMonorepoWorkflow({
               sandbox,
               doesReleaseSpecFileExist: false,
@@ -1535,6 +1674,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1551,6 +1691,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             commitAllChangesSpy,
             projectDirectoryPath,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: false,
@@ -1563,6 +1704,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1576,33 +1718,7 @@ describe('monorepo-workflow-operations', () => {
 
       it('prints a message', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr } = await setupFollowMonorepoWorkflow(
-            {
-              sandbox,
-              doesReleaseSpecFileExist: false,
-              isEditorAvailable: false,
-            },
-          );
-
-          await followMonorepoWorkflow({
-            project,
-            tempDirectoryPath: sandbox.directoryPath,
-            firstRemovingExistingReleaseSpecification: true,
-            releaseType: 'ordinary',
-            defaultBranch: 'main',
-            stdout,
-            stderr,
-          });
-
-          expect(stdout.data()[0]).toMatch(
-            /^A template has been generated that specifies this release/u,
-          );
-        });
-      });
-
-      it('does not remove the generated release spec file', async () => {
-        await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, releaseSpecificationPath } =
+          const { project, stdout, stderr, formatter } =
             await setupFollowMonorepoWorkflow({
               sandbox,
               doesReleaseSpecFileExist: false,
@@ -1615,6 +1731,38 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
+            stdout,
+            stderr,
+          });
+
+          expect(stdout.data()[0]).toMatch(
+            /^A template has been generated that specifies this release/u,
+          );
+        });
+      });
+
+      it('does not remove the generated release spec file', async () => {
+        await withSandbox(async (sandbox) => {
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: false,
+            isEditorAvailable: false,
+          });
+
+          await followMonorepoWorkflow({
+            project,
+            tempDirectoryPath: sandbox.directoryPath,
+            firstRemovingExistingReleaseSpecification: true,
+            releaseType: 'ordinary',
+            defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1632,6 +1780,7 @@ describe('monorepo-workflow-operations', () => {
             stdout,
             stderr,
             generateReleaseSpecificationTemplateForMonorepoSpy,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: true,
@@ -1644,6 +1793,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1665,6 +1815,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             releaseSpecification,
             planReleaseSpy,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: true,
@@ -1677,6 +1828,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1697,6 +1849,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             releaseSpecification,
             planReleaseSpy,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: true,
@@ -1709,6 +1862,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'backport',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1729,6 +1883,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             executeReleasePlanSpy,
             releasePlan,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: true,
@@ -1742,6 +1897,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1749,6 +1905,7 @@ describe('monorepo-workflow-operations', () => {
           expect(executeReleasePlanSpy).toHaveBeenCalledWith(
             project,
             releasePlan,
+            formatter,
             stderr,
           );
         });
@@ -1762,6 +1919,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             commitAllChangesSpy,
             projectDirectoryPath,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: true,
@@ -1775,6 +1933,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1793,12 +1952,17 @@ describe('monorepo-workflow-operations', () => {
 
       it('removes the release spec file after editing, validating, and executing the release spec', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: true,
-              isEditorAvailable: true,
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: true,
+            isEditorAvailable: true,
+          });
 
           await followMonorepoWorkflow({
             project,
@@ -1806,6 +1970,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -1816,7 +1981,7 @@ describe('monorepo-workflow-operations', () => {
 
       it('does not attempt to execute the release spec if it was not successfully edited', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, executeReleasePlanSpy } =
+          const { project, stdout, stderr, executeReleasePlanSpy, formatter } =
             await setupFollowMonorepoWorkflow({
               sandbox,
               doesReleaseSpecFileExist: true,
@@ -1831,6 +1996,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: true,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -1848,6 +2014,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             commitAllChangesSpy,
             projectDirectoryPath,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: true,
@@ -1862,6 +2029,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: true,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -1876,13 +2044,18 @@ describe('monorepo-workflow-operations', () => {
 
       it('removes the release spec file even if it was not successfully edited', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: true,
-              isEditorAvailable: true,
-              errorUponEditingReleaseSpec: new Error('oops'),
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: true,
+            isEditorAvailable: true,
+            errorUponEditingReleaseSpec: new Error('oops'),
+          });
 
           await expect(
             followMonorepoWorkflow({
@@ -1891,6 +2064,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: true,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -1902,14 +2076,13 @@ describe('monorepo-workflow-operations', () => {
 
       it('throws an error produced while editing the release spec', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr } = await setupFollowMonorepoWorkflow(
-            {
+          const { project, stdout, stderr, formatter } =
+            await setupFollowMonorepoWorkflow({
               sandbox,
               doesReleaseSpecFileExist: true,
               isEditorAvailable: true,
               errorUponEditingReleaseSpec: new Error('oops'),
-            },
-          );
+            });
 
           await expect(
             followMonorepoWorkflow({
@@ -1918,6 +2091,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: true,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -1928,13 +2102,18 @@ describe('monorepo-workflow-operations', () => {
       it('does not remove the generated release spec file if it was successfully edited but an error is thrown while validating the release spec', async () => {
         await withSandbox(async (sandbox) => {
           const errorUponValidatingReleaseSpec = new Error('oops');
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: true,
-              isEditorAvailable: true,
-              errorUponValidatingReleaseSpec,
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: true,
+            isEditorAvailable: true,
+            errorUponValidatingReleaseSpec,
+          });
 
           await expect(
             followMonorepoWorkflow({
@@ -1943,6 +2122,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: true,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -1955,14 +2135,19 @@ describe('monorepo-workflow-operations', () => {
       it('does not remove the generated release spec file if it was successfully edited but an error is thrown while planning the release', async () => {
         await withSandbox(async (sandbox) => {
           const errorUponPlanningRelease = new Error('oops');
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: true,
-              isEditorAvailable: true,
-              errorUponPlanningRelease,
-              releaseVersion: '2.0.0',
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: true,
+            isEditorAvailable: true,
+            errorUponPlanningRelease,
+            releaseVersion: '2.0.0',
+          });
 
           await expect(
             followMonorepoWorkflow({
@@ -1971,6 +2156,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: true,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -1983,14 +2169,19 @@ describe('monorepo-workflow-operations', () => {
       it('does not remove the generated release spec file if it was successfully edited but an error is thrown while executing the release plan', async () => {
         await withSandbox(async (sandbox) => {
           const errorUponExecutingReleasePlan = new Error('oops');
-          const { project, stdout, stderr, releaseSpecificationPath } =
-            await setupFollowMonorepoWorkflow({
-              sandbox,
-              doesReleaseSpecFileExist: true,
-              isEditorAvailable: true,
-              errorUponExecutingReleasePlan,
-              releaseVersion: '2.0.0',
-            });
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: true,
+            isEditorAvailable: true,
+            errorUponExecutingReleasePlan,
+            releaseVersion: '2.0.0',
+          });
 
           await expect(
             followMonorepoWorkflow({
@@ -1999,6 +2190,7 @@ describe('monorepo-workflow-operations', () => {
               firstRemovingExistingReleaseSpecification: true,
               releaseType: 'ordinary',
               defaultBranch: 'main',
+              formatter,
               stdout,
               stderr,
             }),
@@ -2017,6 +2209,7 @@ describe('monorepo-workflow-operations', () => {
             stdout,
             stderr,
             generateReleaseSpecificationTemplateForMonorepoSpy,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: true,
@@ -2029,6 +2222,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -2044,7 +2238,7 @@ describe('monorepo-workflow-operations', () => {
 
       it('does not attempt to execute the edited release spec', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, executeReleasePlanSpy } =
+          const { project, stdout, stderr, executeReleasePlanSpy, formatter } =
             await setupFollowMonorepoWorkflow({
               sandbox,
               doesReleaseSpecFileExist: true,
@@ -2057,6 +2251,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -2073,6 +2268,7 @@ describe('monorepo-workflow-operations', () => {
             stderr,
             commitAllChangesSpy,
             projectDirectoryPath,
+            formatter,
           } = await setupFollowMonorepoWorkflow({
             sandbox,
             doesReleaseSpecFileExist: true,
@@ -2085,6 +2281,7 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });
@@ -2098,33 +2295,7 @@ describe('monorepo-workflow-operations', () => {
 
       it('prints a message', async () => {
         await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr } = await setupFollowMonorepoWorkflow(
-            {
-              sandbox,
-              doesReleaseSpecFileExist: true,
-              isEditorAvailable: false,
-            },
-          );
-
-          await followMonorepoWorkflow({
-            project,
-            tempDirectoryPath: sandbox.directoryPath,
-            firstRemovingExistingReleaseSpecification: true,
-            releaseType: 'ordinary',
-            defaultBranch: 'main',
-            stdout,
-            stderr,
-          });
-
-          expect(stdout.data()[0]).toMatch(
-            /^A template has been generated that specifies this release/u,
-          );
-        });
-      });
-
-      it('does not remove the generated release spec file', async () => {
-        await withSandbox(async (sandbox) => {
-          const { project, stdout, stderr, releaseSpecificationPath } =
+          const { project, stdout, stderr, formatter } =
             await setupFollowMonorepoWorkflow({
               sandbox,
               doesReleaseSpecFileExist: true,
@@ -2137,6 +2308,38 @@ describe('monorepo-workflow-operations', () => {
             firstRemovingExistingReleaseSpecification: true,
             releaseType: 'ordinary',
             defaultBranch: 'main',
+            formatter,
+            stdout,
+            stderr,
+          });
+
+          expect(stdout.data()[0]).toMatch(
+            /^A template has been generated that specifies this release/u,
+          );
+        });
+      });
+
+      it('does not remove the generated release spec file', async () => {
+        await withSandbox(async (sandbox) => {
+          const {
+            project,
+            stdout,
+            stderr,
+            releaseSpecificationPath,
+            formatter,
+          } = await setupFollowMonorepoWorkflow({
+            sandbox,
+            doesReleaseSpecFileExist: true,
+            isEditorAvailable: false,
+          });
+
+          await followMonorepoWorkflow({
+            project,
+            tempDirectoryPath: sandbox.directoryPath,
+            firstRemovingExistingReleaseSpecification: true,
+            releaseType: 'ordinary',
+            defaultBranch: 'main',
+            formatter,
             stdout,
             stderr,
           });

--- a/src/monorepo-workflow-operations.ts
+++ b/src/monorepo-workflow-operations.ts
@@ -7,7 +7,7 @@ import {
   writeFile,
 } from './fs.js';
 import { determineEditor } from './editor.js';
-import { ReleaseType } from './initial-parameters.js';
+import { Formatter, ReleaseType } from './initial-parameters.js';
 import {
   Project,
   updateChangelogsForChangedPackages,
@@ -57,6 +57,7 @@ import {
  * @param args.releaseType - The type of release ("ordinary" or "backport"),
  * which affects how the version is bumped.
  * @param args.defaultBranch - The name of the default branch in the repository.
+ * @param args.formatter - The formatter to use for formatting the changelog.
  * @param args.stdout - A stream that can be used to write to standard out.
  * @param args.stderr - A stream that can be used to write to standard error.
  */
@@ -66,6 +67,7 @@ export async function followMonorepoWorkflow({
   firstRemovingExistingReleaseSpecification,
   releaseType,
   defaultBranch,
+  formatter,
   stdout,
   stderr,
 }: {
@@ -74,6 +76,7 @@ export async function followMonorepoWorkflow({
   firstRemovingExistingReleaseSpecification: boolean;
   releaseType: ReleaseType;
   defaultBranch: string;
+  formatter: Formatter;
   stdout: Pick<WriteStream, 'write'>;
   stderr: Pick<WriteStream, 'write'>;
 }) {
@@ -83,7 +86,7 @@ export async function followMonorepoWorkflow({
   });
 
   if (firstRun) {
-    await updateChangelogsForChangedPackages({ project, stderr });
+    await updateChangelogsForChangedPackages({ project, formatter, stderr });
     await commitAllChanges(
       project.directoryPath,
       `Initialize Release ${newReleaseVersion}`,
@@ -150,7 +153,7 @@ export async function followMonorepoWorkflow({
     releaseSpecificationPackages: packages,
     newReleaseVersion,
   });
-  await executeReleasePlan(project, releasePlan, stderr);
+  await executeReleasePlan(project, releasePlan, formatter, stderr);
   await removeFile(releaseSpecificationPath);
   await fixConstraints(project.directoryPath);
   await updateYarnLockfile(project.directoryPath);

--- a/src/package.test.ts
+++ b/src/package.test.ts
@@ -4,7 +4,11 @@ import { when } from 'jest-when';
 import * as autoChangelog from '@metamask/auto-changelog';
 import { SemVer } from 'semver';
 import { MockWritable } from 'stdio-mock';
-import { buildChangelog, withSandbox } from '../tests/helpers.js';
+import {
+  buildChangelog,
+  normalizeMultilineString,
+  withSandbox,
+} from '../tests/helpers.js';
 import {
   buildMockPackage,
   buildMockProject,
@@ -12,7 +16,7 @@ import {
   createNoopWriteStream,
 } from '../tests/unit/helpers.js';
 import {
-  formatChangelog,
+  getFormatter,
   readMonorepoRootPackage,
   readMonorepoWorkspacePackage,
   updatePackage,
@@ -24,6 +28,23 @@ import * as repoModule from './repo.js';
 
 jest.mock('./package-manifest');
 jest.mock('./repo');
+jest.mock('@metamask/auto-changelog', () => ({
+  ...jest.requireActual('@metamask/auto-changelog'),
+  updateChangelog: jest.fn(),
+
+  // Replacing the implementation of the `oxfmt` function because Jest
+  // doesn't work well with dynamic imports, and Oxfmt is ESM-only.
+  oxfmt: async (content: string) => content,
+
+  // Replacing the implementation of the `prettier` function because Jest
+  // doesn't work well with dynamic imports.
+  prettier: async (content: string) => {
+    const markdown = jest.requireActual('prettier/plugins/markdown');
+    return await jest
+      .requireActual('prettier/standalone')
+      .format(content, { parser: 'markdown', plugins: [markdown] });
+  },
+}));
 
 describe('package', () => {
   describe('readMonorepoRootPackage', () => {
@@ -440,7 +461,11 @@ describe('package', () => {
           newVersion: '2.0.0',
         };
 
-        await updatePackage({ project, packageReleasePlan });
+        await updatePackage({
+          project,
+          packageReleasePlan,
+          formatter: 'prettier',
+        });
 
         const newManifest = JSON.parse(
           await fs.promises.readFile(manifestPath, 'utf8'),
@@ -483,7 +508,11 @@ describe('package', () => {
           `),
         );
 
-        await updatePackage({ project, packageReleasePlan });
+        await updatePackage({
+          project,
+          packageReleasePlan,
+          formatter: 'prettier',
+        });
 
         const newChangelogContent = await fs.promises.readFile(
           changelogPath,
@@ -514,6 +543,75 @@ describe('package', () => {
       });
     });
 
+    it('migrates all unreleased changes to a release section with Oxfmt', async () => {
+      await withSandbox(async (sandbox) => {
+        const project = buildMockProject({
+          repositoryUrl: 'https://repo.url',
+        });
+        const changelogPath = path.join(sandbox.directoryPath, 'CHANGELOG.md');
+        const packageReleasePlan = {
+          package: buildMockPackage({
+            directoryPath: sandbox.directoryPath,
+            manifestPath: path.join(sandbox.directoryPath, 'package.json'),
+            validatedManifest: buildMockManifest(),
+            changelogPath,
+          }),
+          newVersion: '2.0.0',
+        };
+
+        await fs.promises.writeFile(
+          changelogPath,
+          buildChangelog(`
+            ## [Unreleased]
+            ### Uncategorized
+            - Add isNewFunction ([#2](https://repo.url/compare/package/pull/2))
+
+            ## [1.0.0] - 2020-01-01
+            ### Changed
+            - Something else
+
+            [Unreleased]: https://repo.url/compare/package@2.0.0...HEAD
+            [1.0.0]: https://repo.url/releases/tag/package@1.0.0
+          `),
+        );
+
+        await updatePackage({
+          project,
+          packageReleasePlan,
+          formatter: 'oxfmt',
+        });
+
+        const newChangelogContent = await fs.promises.readFile(
+          changelogPath,
+          'utf8',
+        );
+
+        expect(newChangelogContent).toBe(
+          normalizeMultilineString(`
+            # Changelog
+            All notable changes to this project will be documented in this file.
+
+            The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+            and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+            ## [Unreleased]
+
+            ## [2.0.0]
+            ### Uncategorized
+            - Add isNewFunction ([#2](https://repo.url/compare/package/pull/2))
+
+            ## [1.0.0] - 2020-01-01
+            ### Changed
+            - Something else
+
+            [Unreleased]: https://repo.url/compare/package@2.0.0...HEAD
+            [2.0.0]: https://repo.url/compare/package@1.0.0...package@2.0.0
+            [1.0.0]: https://repo.url/releases/tag/package@1.0.0
+          `),
+        );
+      });
+    });
+
     it("throws if reading the package's changelog fails in an unexpected way", async () => {
       await withSandbox(async (sandbox) => {
         const project = buildMockProject();
@@ -530,7 +628,7 @@ describe('package', () => {
         jest.spyOn(fsModule, 'readFile').mockRejectedValue(new Error('oops'));
 
         await expect(
-          updatePackage({ project, packageReleasePlan }),
+          updatePackage({ project, packageReleasePlan, formatter: 'prettier' }),
         ).rejects.toThrow('oops');
       });
     });
@@ -549,7 +647,11 @@ describe('package', () => {
           newVersion: '2.0.0',
         };
 
-        const result = await updatePackage({ project, packageReleasePlan });
+        const result = await updatePackage({
+          project,
+          packageReleasePlan,
+          formatter: 'prettier',
+        });
 
         expect(result).toBeUndefined();
       });
@@ -577,7 +679,7 @@ describe('package', () => {
             projectRootDirectory: sandbox.directoryPath,
             repoUrl: 'https://repo.url',
             tagPrefixes: ['package@', 'v'],
-            formatter: formatChangelog,
+            formatter: expect.any(Function),
           })
           .mockResolvedValue('new changelog');
         await fs.promises.writeFile(changelogPath, 'existing changelog');
@@ -585,6 +687,7 @@ describe('package', () => {
         await updatePackageChangelog({
           project,
           package: pkg,
+          formatter: 'prettier',
           stderr,
         });
 
@@ -616,7 +719,7 @@ describe('package', () => {
             projectRootDirectory: sandbox.directoryPath,
             repoUrl: 'https://repo.url',
             tagPrefixes: ['package@', 'v'],
-            formatter: formatChangelog,
+            formatter: expect.any(Function),
           })
           .mockResolvedValue(undefined);
         await fs.promises.writeFile(changelogPath, 'existing changelog');
@@ -624,6 +727,7 @@ describe('package', () => {
         await updatePackageChangelog({
           project,
           package: pkg,
+          formatter: 'prettier',
           stderr,
         });
 
@@ -652,6 +756,7 @@ describe('package', () => {
         const result = await updatePackageChangelog({
           project,
           package: pkg,
+          formatter: 'prettier',
           stderr,
         });
 
@@ -675,36 +780,33 @@ describe('package', () => {
         jest.spyOn(fsModule, 'readFile').mockRejectedValue(new Error('oops'));
 
         await expect(
-          updatePackageChangelog({ project, package: pkg, stderr }),
+          updatePackageChangelog({
+            project,
+            package: pkg,
+            formatter: 'prettier',
+            stderr,
+          }),
         ).rejects.toThrow('oops');
       });
     });
   });
 
-  describe('formatChangelog', () => {
-    it('formats a changelog', async () => {
-      const unformattedChangelog = `#  Changelog
-##     1.0.0
+  describe('getFormatter', () => {
+    it('returns the Oxfmt formatter', async () => {
+      const formatter = await getFormatter('oxfmt');
+      expect(formatter).toBe(autoChangelog.oxfmt);
+    });
 
- - Some change
-## 0.0.1
+    it('returns the Prettier formatter', async () => {
+      const formatter = await getFormatter('prettier');
+      expect(formatter).toBe(autoChangelog.prettier);
+    });
 
-- Some other change
-`;
-
-      expect(await formatChangelog(unformattedChangelog))
-        .toMatchInlineSnapshot(`
-        "# Changelog
-
-        ## 1.0.0
-
-        - Some change
-
-        ## 0.0.1
-
-        - Some other change
-        "
-      `);
+    it('throws if an unknown formatter name is given', async () => {
+      // @ts-expect-error: Invalid formatter name for testing purposes.
+      expect(() => getFormatter('some-unknown-formatter')).toThrow(
+        'Invalid branch reached. Should be detected during compilation.',
+      );
     });
   });
 });

--- a/src/package.ts
+++ b/src/package.ts
@@ -1,9 +1,13 @@
 import fs, { WriteStream } from 'fs';
 import path from 'path';
 import { format } from 'util';
-import { parseChangelog, updateChangelog } from '@metamask/auto-changelog';
-import { format as formatPrettier } from 'prettier/standalone';
-import * as markdown from 'prettier/plugins/markdown';
+import {
+  oxfmt,
+  parseChangelog,
+  prettier,
+  updateChangelog,
+} from '@metamask/auto-changelog';
+import { assertExhaustive } from '@metamask/utils';
 import { WriteStreamLike, readFile, writeFile, writeJsonFile } from './fs.js';
 import { isErrorWithCode } from './misc-utils.js';
 import {
@@ -15,6 +19,7 @@ import { Project } from './project.js';
 import { PackageReleasePlan } from './release-plan.js';
 import { hasChangesInDirectorySinceGitTag } from './repo.js';
 import { SemVer } from './semver.js';
+import { Formatter } from './initial-parameters.js';
 
 const MANIFEST_FILE_NAME = 'package.json';
 const CHANGELOG_FILE_NAME = 'CHANGELOG.md';
@@ -232,6 +237,27 @@ export async function readMonorepoWorkspacePackage({
 }
 
 /**
+ * Get the formatting function for the given formatter name.
+ *
+ * @param formatter - The name of the formatter.
+ * @returns The formatting function.
+ */
+export function getFormatter(
+  formatter: 'oxfmt' | 'prettier',
+): (changelog: string) => Promise<string> {
+  switch (formatter) {
+    case 'oxfmt':
+      return oxfmt;
+
+    case 'prettier':
+      return prettier;
+
+    default:
+      return assertExhaustive(formatter);
+  }
+}
+
+/**
  * Migrate all unreleased changes to a release section.
  *
  * Changes are migrated in their existing categories, and placed above any
@@ -241,6 +267,7 @@ export async function readMonorepoWorkspacePackage({
  * @param args.project - The project.
  * @param args.package - A particular package in the project.
  * @param args.version - The release version to migrate unreleased changes to.
+ * @param args.formatter - The formatter to use for formatting the changelog.
  * @param args.stderr - A stream that can be used to write to standard error.
  * @returns The result of writing to the changelog.
  */
@@ -248,11 +275,13 @@ export async function migrateUnreleasedChangelogChangesToRelease({
   project: { repositoryUrl },
   package: pkg,
   version,
+  formatter,
   stderr,
 }: {
   project: Pick<Project, 'directoryPath' | 'repositoryUrl'>;
   package: Package;
   version: string;
+  formatter: Formatter;
   stderr: Pick<WriteStream, 'write'>;
 }): Promise<void> {
   let changelogContent;
@@ -274,26 +303,12 @@ export async function migrateUnreleasedChangelogChangesToRelease({
     changelogContent,
     repoUrl: repositoryUrl,
     tagPrefix: `${pkg.validatedManifest.name}@`,
-    formatter: formatChangelog,
+    formatter: getFormatter(formatter),
   });
 
   changelog.addRelease({ version });
   changelog.migrateUnreleasedChangesToRelease(version);
   await writeFile(pkg.changelogPath, await changelog.toString());
-}
-
-/**
- * Format the given changelog using Prettier. This is extracted into a separate
- * function for coverage purposes.
- *
- * @param changelog - The changelog to format.
- * @returns The formatted changelog.
- */
-export async function formatChangelog(changelog: string) {
-  return await formatPrettier(changelog, {
-    parser: 'markdown',
-    plugins: [markdown],
-  });
 }
 
 /**
@@ -304,16 +319,19 @@ export async function formatChangelog(changelog: string) {
  * @param args - The arguments.
  * @param args.project - The project.
  * @param args.package - A particular package in the project.
+ * @param args.formatter - The formatter to use for formatting the changelog.
  * @param args.stderr - A stream that can be used to write to standard error.
  * @returns The result of writing to the changelog.
  */
 export async function updatePackageChangelog({
   project: { repositoryUrl },
   package: pkg,
+  formatter,
   stderr,
 }: {
   project: Pick<Project, 'directoryPath' | 'repositoryUrl'>;
   package: Package;
+  formatter: Formatter;
   stderr: Pick<WriteStream, 'write'>;
 }): Promise<void> {
   let changelogContent;
@@ -340,7 +358,7 @@ export async function updatePackageChangelog({
     projectRootDirectory: pkg.directoryPath,
     repoUrl: repositoryUrl,
     tagPrefixes: [`${pkg.validatedManifest.name}@`, 'v'],
-    formatter: formatChangelog,
+    formatter: getFormatter(formatter),
   });
 
   if (newChangelogContent) {
@@ -362,16 +380,19 @@ export async function updatePackageChangelog({
  * @param args.project - The project.
  * @param args.packageReleasePlan - The release plan for a particular package in the
  * project.
+ * @param args.formatter - The formatter to use for formatting the changelog.
  * @param args.stderr - A stream that can be used to write to standard error.
  * Defaults to /dev/null.
  */
 export async function updatePackage({
   project,
   packageReleasePlan,
+  formatter,
   stderr = fs.createWriteStream('/dev/null'),
 }: {
   project: Pick<Project, 'directoryPath' | 'repositoryUrl'>;
   packageReleasePlan: PackageReleasePlan;
+  formatter: Formatter;
   stderr?: Pick<WriteStream, 'write'>;
 }): Promise<void> {
   const { package: pkg, newVersion } = packageReleasePlan;
@@ -384,6 +405,7 @@ export async function updatePackage({
   await migrateUnreleasedChangelogChangesToRelease({
     project,
     package: pkg,
+    formatter,
     stderr,
     version: newVersion,
   });

--- a/src/project.test.ts
+++ b/src/project.test.ts
@@ -327,6 +327,7 @@ describe('project', () => {
 
       await updateChangelogsForChangedPackages({
         project,
+        formatter: 'prettier',
         stderr,
       });
 
@@ -361,6 +362,7 @@ describe('project', () => {
 
       await updateChangelogsForChangedPackages({
         project,
+        formatter: 'prettier',
         stderr,
       });
 

--- a/src/project.test.ts
+++ b/src/project.test.ts
@@ -334,12 +334,14 @@ describe('project', () => {
       expect(updatePackageChangelogSpy).toHaveBeenCalledWith({
         project,
         package: project.workspacePackages.a,
+        formatter: 'prettier',
         stderr,
       });
 
       expect(updatePackageChangelogSpy).toHaveBeenCalledWith({
         project,
         package: project.workspacePackages.b,
+        formatter: 'prettier',
         stderr,
       });
     });

--- a/src/project.ts
+++ b/src/project.ts
@@ -20,6 +20,7 @@ import {
   convertToHttpsGitHubRepositoryUrl,
   getStdoutFromCommand,
 } from './misc-utils.js';
+import { Formatter } from './initial-parameters.js';
 
 /**
  * The release version of the root package of a monorepo extracted from its
@@ -205,16 +206,19 @@ export async function getValidRepositoryUrl(
  * @param args - The arguments.
  * @param args.project - The project.
  * @param args.stderr - A stream that can be used to write to standard error.
+ * @param args.formatter - The formatter to use for formatting the changelog.
  * @returns The result of writing to the changelog.
  */
 export async function updateChangelogsForChangedPackages({
   project,
+  formatter,
   stderr,
 }: {
   project: Pick<
     Project,
     'directoryPath' | 'repositoryUrl' | 'workspacePackages'
   >;
+  formatter: Formatter;
   stderr: Pick<WriteStream, 'write'>;
 }): Promise<void> {
   await Promise.all(
@@ -225,6 +229,7 @@ export async function updateChangelogsForChangedPackages({
       .map((pkg) =>
         updatePackageChangelog({
           project,
+          formatter,
           package: pkg,
           stderr,
         }),

--- a/src/release-plan.test.ts
+++ b/src/release-plan.test.ts
@@ -181,16 +181,18 @@ describe('release-plan-utils', () => {
       const stderr = fs.createWriteStream('/dev/null');
       const updatePackageSpy = jest.spyOn(packageUtils, 'updatePackage');
 
-      await executeReleasePlan(project, releasePlan, stderr);
+      await executeReleasePlan(project, releasePlan, 'prettier', stderr);
 
       expect(updatePackageSpy).toHaveBeenNthCalledWith(1, {
         project,
         packageReleasePlan: releasePlan.packages[0],
+        formatter: 'prettier',
         stderr,
       });
       expect(updatePackageSpy).toHaveBeenNthCalledWith(2, {
         project,
         packageReleasePlan: releasePlan.packages[1],
+        formatter: 'prettier',
         stderr,
       });
     });

--- a/src/release-plan.ts
+++ b/src/release-plan.ts
@@ -4,6 +4,7 @@ import { debug } from './misc-utils.js';
 import { Package, updatePackage } from './package.js';
 import { Project } from './project.js';
 import { ReleaseSpecification } from './release-specification.js';
+import { Formatter } from './initial-parameters.js';
 
 /**
  * Instructions for how to update the project in order to prepare it for a new
@@ -96,11 +97,13 @@ export async function planRelease({
  * and where they can found).
  * @param releasePlan - Compiled instructions on how exactly to update the
  * project in order to prepare a new release.
+ * @param formatter - The formatter to use for formatting the changelog.
  * @param stderr - A stream that can be used to write to standard error.
  */
 export async function executeReleasePlan(
   project: Project,
   releasePlan: ReleasePlan,
+  formatter: Formatter,
   stderr: Pick<WriteStream, 'write'>,
 ) {
   await Promise.all(
@@ -111,6 +114,7 @@ export async function executeReleasePlan(
       await updatePackage({
         project,
         packageReleasePlan: workspaceReleasePlan,
+        formatter,
         stderr,
       });
     }),

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -28,6 +28,7 @@ import {
 } from './yarn-commands.js';
 import { readFile } from './fs.js';
 import { getCurrentDirectoryPath } from './dirname.js';
+import { Formatter } from './initial-parameters.js';
 
 const UI_BUILD_DIR = join(getCurrentDirectoryPath(), 'ui');
 
@@ -36,6 +37,7 @@ type UIOptions = {
   releaseType: 'ordinary' | 'backport';
   defaultBranch: string;
   port: number;
+  formatter: Formatter;
   stdout: Pick<WriteStream, 'write'>;
   stderr: Pick<WriteStream, 'write'>;
 };
@@ -48,6 +50,7 @@ type UIOptions = {
  * @param options.releaseType - The type of release.
  * @param options.defaultBranch - The default branch name.
  * @param options.port - The port number for the server.
+ * @param options.formatter - The formatter to use for formatting the changelog.
  * @param options.stdout - The stdout stream.
  * @param options.stderr - The stderr stream.
  */
@@ -56,6 +59,7 @@ export async function startUI({
   releaseType,
   defaultBranch,
   port,
+  formatter,
   stdout,
   stderr,
 }: UIOptions): Promise<void> {
@@ -65,7 +69,7 @@ export async function startUI({
   });
 
   if (firstRun) {
-    await updateChangelogsForChangedPackages({ project, stderr });
+    await updateChangelogsForChangedPackages({ project, formatter, stderr });
     await commitAllChanges(
       project.directoryPath,
       `Initialize Release ${newReleaseVersion}`,
@@ -75,6 +79,7 @@ export async function startUI({
   const app = createApp({
     project,
     defaultBranch,
+    formatter,
     stderr,
     version: newReleaseVersion,
     closeServer: () => {
@@ -118,6 +123,7 @@ export async function startUI({
  * @param options - The options for creating the app.
  * @param options.project - The project object.
  * @param options.defaultBranch - The default branch name.
+ * @param options.formatter - The formatter to use for formatting the changelog.
  * @param options.stderr - The stderr stream.
  * @param options.version - The release version.
  * @param options.closeServer - The function to close the server.
@@ -126,12 +132,14 @@ export async function startUI({
 function createApp({
   project,
   defaultBranch,
+  formatter,
   stderr,
   version,
   closeServer,
 }: {
   project: Project;
   defaultBranch: string;
+  formatter: Formatter;
   stderr: Pick<WriteStream, 'write'>;
   version: string;
   closeServer: () => void;
@@ -328,7 +336,7 @@ function createApp({
           releaseSpecificationPackages,
           newReleaseVersion: version,
         });
-        await executeReleasePlan(project, releasePlan, stderr);
+        await executeReleasePlan(project, releasePlan, formatter, stderr);
         await fixConstraints(project.directoryPath);
         await updateYarnLockfile(project.directoryPath);
         await deduplicateDependencies(project.directoryPath);

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,17 +15,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.22.13, @babel/code-frame@npm:^7.23.5":
-  version: 7.23.5
-  resolution: "@babel/code-frame@npm:7.23.5"
-  dependencies:
-    "@babel/highlight": ^7.23.4
-    chalk: ^2.4.2
-  checksum: d90981fdf56a2824a9b14d19a4c0e8db93633fd488c772624b4e83e0ceac6039a27cd298a247c3214faa952bf803ba23696172ae7e7235f3b97f43ba278c569a
-  languageName: node
-  linkType: hard
-
-"@babel/code-frame@npm:^7.26.2":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.26.2":
   version: 7.26.2
   resolution: "@babel/code-frame@npm:7.26.2"
   dependencies:
@@ -36,44 +26,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.22.9, @babel/compat-data@npm:^7.23.3, @babel/compat-data@npm:^7.23.5":
-  version: 7.23.5
-  resolution: "@babel/compat-data@npm:7.23.5"
-  checksum: 06ce244cda5763295a0ea924728c09bae57d35713b675175227278896946f922a63edf803c322f855a3878323d48d0255a2a3023409d2a123483c8a69ebb4744
-  languageName: node
-  linkType: hard
-
-"@babel/compat-data@npm:^7.26.5":
+"@babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.23.3, @babel/compat-data@npm:^7.23.5, @babel/compat-data@npm:^7.26.5":
   version: 7.26.8
   resolution: "@babel/compat-data@npm:7.26.8"
   checksum: 1bb04c6860c8c9555b933cb9c3caf5ef1dac331a37a351efb67956fc679f695d487aea76e792dd43823702c1300f7906f2a298e50b4a8d7ec199ada9c340c365
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.23.5":
-  version: 7.23.5
-  resolution: "@babel/core@npm:7.23.5"
-  dependencies:
-    "@ampproject/remapping": ^2.2.0
-    "@babel/code-frame": ^7.23.5
-    "@babel/generator": ^7.23.5
-    "@babel/helper-compilation-targets": ^7.22.15
-    "@babel/helper-module-transforms": ^7.23.3
-    "@babel/helpers": ^7.23.5
-    "@babel/parser": ^7.23.5
-    "@babel/template": ^7.22.15
-    "@babel/traverse": ^7.23.5
-    "@babel/types": ^7.23.5
-    convert-source-map: ^2.0.0
-    debug: ^4.1.0
-    gensync: ^1.0.0-beta.2
-    json5: ^2.2.3
-    semver: ^6.3.1
-  checksum: 5e5dfb1e61f298676f1fca18c646dbf6fb164ca1056b0169b8d42b7f5c35e026d81823582ccb2358e93a61b035e22b3ad37e2abaae4bf43f1ffb93b6ce19466e
-  languageName: node
-  linkType: hard
-
-"@babel/core@npm:^7.26.0":
+"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.23.5, @babel/core@npm:^7.26.0":
   version: 7.26.9
   resolution: "@babel/core@npm:7.26.9"
   dependencies:
@@ -96,19 +56,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.23.5, @babel/generator@npm:^7.7.2":
-  version: 7.23.5
-  resolution: "@babel/generator@npm:7.23.5"
-  dependencies:
-    "@babel/types": ^7.23.5
-    "@jridgewell/gen-mapping": ^0.3.2
-    "@jridgewell/trace-mapping": ^0.3.17
-    jsesc: ^2.5.1
-  checksum: 845ddda7cf38a3edf4be221cc8a439dee9ea6031355146a1a74047aa8007bc030305b27d8c68ec9e311722c910610bde38c0e13a9ce55225251e7cb7e7f3edc8
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.26.9":
+"@babel/generator@npm:^7.26.9, @babel/generator@npm:^7.7.2":
   version: 7.26.9
   resolution: "@babel/generator@npm:7.26.9"
   dependencies:
@@ -139,20 +87,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.22.15, @babel/helper-compilation-targets@npm:^7.22.6":
-  version: 7.22.15
-  resolution: "@babel/helper-compilation-targets@npm:7.22.15"
-  dependencies:
-    "@babel/compat-data": ^7.22.9
-    "@babel/helper-validator-option": ^7.22.15
-    browserslist: ^4.21.9
-    lru-cache: ^5.1.1
-    semver: ^6.3.1
-  checksum: ce85196769e091ae54dd39e4a80c2a9df1793da8588e335c383d536d54f06baf648d0a08fc873044f226398c4ded15c4ae9120ee18e7dfd7c639a68e3cdc9980
-  languageName: node
-  linkType: hard
-
-"@babel/helper-compilation-targets@npm:^7.26.5":
+"@babel/helper-compilation-targets@npm:^7.22.15, @babel/helper-compilation-targets@npm:^7.22.6, @babel/helper-compilation-targets@npm:^7.26.5":
   version: 7.26.5
   resolution: "@babel/helper-compilation-targets@npm:7.26.5"
   dependencies:
@@ -247,16 +182,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.22.15":
-  version: 7.22.15
-  resolution: "@babel/helper-module-imports@npm:7.22.15"
-  dependencies:
-    "@babel/types": ^7.22.15
-  checksum: ecd7e457df0a46f889228f943ef9b4a47d485d82e030676767e6a2fdcbdaa63594d8124d4b55fd160b41c201025aec01fc27580352b1c87a37c9c6f33d116702
-  languageName: node
-  linkType: hard
-
-"@babel/helper-module-imports@npm:^7.25.9":
+"@babel/helper-module-imports@npm:^7.22.15, @babel/helper-module-imports@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-module-imports@npm:7.25.9"
   dependencies:
@@ -266,22 +192,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.23.3":
-  version: 7.23.3
-  resolution: "@babel/helper-module-transforms@npm:7.23.3"
-  dependencies:
-    "@babel/helper-environment-visitor": ^7.22.20
-    "@babel/helper-module-imports": ^7.22.15
-    "@babel/helper-simple-access": ^7.22.5
-    "@babel/helper-split-export-declaration": ^7.22.6
-    "@babel/helper-validator-identifier": ^7.22.20
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 5d0895cfba0e16ae16f3aa92fee108517023ad89a855289c4eb1d46f7aef4519adf8e6f971e1d55ac20c5461610e17213f1144097a8f932e768a9132e2278d71
-  languageName: node
-  linkType: hard
-
-"@babel/helper-module-transforms@npm:^7.26.0":
+"@babel/helper-module-transforms@npm:^7.23.3, @babel/helper-module-transforms@npm:^7.26.0":
   version: 7.26.0
   resolution: "@babel/helper-module-transforms@npm:7.26.0"
   dependencies:
@@ -303,14 +214,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.8.0, @babel/helper-plugin-utils@npm:^7.8.3":
-  version: 7.22.5
-  resolution: "@babel/helper-plugin-utils@npm:7.22.5"
-  checksum: c0fc7227076b6041acd2f0e818145d2e8c41968cc52fb5ca70eed48e21b8fe6dd88a0a91cbddf4951e33647336eb5ae184747ca706817ca3bef5e9e905151ff5
-  languageName: node
-  linkType: hard
-
-"@babel/helper-plugin-utils@npm:^7.25.9":
+"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.25.9, @babel/helper-plugin-utils@npm:^7.8.0, @babel/helper-plugin-utils@npm:^7.8.3":
   version: 7.26.5
   resolution: "@babel/helper-plugin-utils@npm:7.26.5"
   checksum: 4771fbb1711c624c62d12deabc2ed7435a6e6994b6ce09d5ede1bc1bf19be59c3775461a1e693bdd596af865685e87bb2abc778f62ceadc1b2095a8e2aa74180
@@ -370,13 +274,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-string-parser@npm:^7.23.4":
-  version: 7.23.4
-  resolution: "@babel/helper-string-parser@npm:7.23.4"
-  checksum: c0641144cf1a7e7dc93f3d5f16d5327465b6cf5d036b48be61ecba41e1eece161b48f46b7f960951b67f8c3533ce506b16dece576baef4d8b3b49f8c65410f90
-  languageName: node
-  linkType: hard
-
 "@babel/helper-string-parser@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-string-parser@npm:7.25.9"
@@ -384,28 +281,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.22.20":
-  version: 7.22.20
-  resolution: "@babel/helper-validator-identifier@npm:7.22.20"
-  checksum: 136412784d9428266bcdd4d91c32bcf9ff0e8d25534a9d94b044f77fe76bc50f941a90319b05aafd1ec04f7d127cd57a179a3716009ff7f3412ef835ada95bdc
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-identifier@npm:^7.25.9":
+"@babel/helper-validator-identifier@npm:^7.22.20, @babel/helper-validator-identifier@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-validator-identifier@npm:7.25.9"
   checksum: 5b85918cb1a92a7f3f508ea02699e8d2422fe17ea8e82acd445006c0ef7520fbf48e3dbcdaf7b0a1d571fc3a2715a29719e5226636cb6042e15fe6ed2a590944
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-option@npm:^7.22.15, @babel/helper-validator-option@npm:^7.23.5":
-  version: 7.23.5
-  resolution: "@babel/helper-validator-option@npm:7.23.5"
-  checksum: 537cde2330a8aede223552510e8a13e9c1c8798afee3757995a7d4acae564124fe2bf7e7c3d90d62d3657434a74340a274b3b3b1c6f17e9a2be1f48af29cb09e
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-option@npm:^7.25.9":
+"@babel/helper-validator-option@npm:^7.22.15, @babel/helper-validator-option@npm:^7.23.5, @babel/helper-validator-option@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-validator-option@npm:7.25.9"
   checksum: 9491b2755948ebbdd68f87da907283698e663b5af2d2b1b02a2765761974b1120d5d8d49e9175b167f16f72748ffceec8c9cf62acfbee73f4904507b246e2b3d
@@ -423,17 +306,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.23.5":
-  version: 7.23.5
-  resolution: "@babel/helpers@npm:7.23.5"
-  dependencies:
-    "@babel/template": ^7.22.15
-    "@babel/traverse": ^7.23.5
-    "@babel/types": ^7.23.5
-  checksum: c16dc8a3bb3d0e02c7ee1222d9d0865ed4b92de44fb8db43ff5afd37a0fc9ea5e2906efa31542c95b30c1a3a9540d66314663c9a23b5bb9b5ec76e8ebc896064
-  languageName: node
-  linkType: hard
-
 "@babel/helpers@npm:^7.26.9":
   version: 7.26.9
   resolution: "@babel/helpers@npm:7.26.9"
@@ -444,27 +316,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/highlight@npm:^7.23.4":
-  version: 7.23.4
-  resolution: "@babel/highlight@npm:7.23.4"
-  dependencies:
-    "@babel/helper-validator-identifier": ^7.22.20
-    chalk: ^2.4.2
-    js-tokens: ^4.0.0
-  checksum: 643acecdc235f87d925979a979b539a5d7d1f31ae7db8d89047269082694122d11aa85351304c9c978ceeb6d250591ccadb06c366f358ccee08bb9c122476b89
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.22.15, @babel/parser@npm:^7.23.5":
-  version: 7.23.5
-  resolution: "@babel/parser@npm:7.23.5"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: ea763629310f71580c4a3ea9d3705195b7ba994ada2cc98f9a584ebfdacf54e92b2735d351672824c2c2b03c7f19206899f4d95650d85ce514a822b19a8734c7
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.20.7, @babel/parser@npm:^7.26.9":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.26.9":
   version: 7.26.9
   resolution: "@babel/parser@npm:7.26.9"
   dependencies:
@@ -1502,18 +1354,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.22.15, @babel/template@npm:^7.3.3":
-  version: 7.22.15
-  resolution: "@babel/template@npm:7.22.15"
-  dependencies:
-    "@babel/code-frame": ^7.22.13
-    "@babel/parser": ^7.22.15
-    "@babel/types": ^7.22.15
-  checksum: 1f3e7dcd6c44f5904c184b3f7fe280394b191f2fed819919ffa1e529c259d5b197da8981b6ca491c235aee8dbad4a50b7e31304aa531271cb823a4a24a0dd8fd
-  languageName: node
-  linkType: hard
-
-"@babel/template@npm:^7.26.9":
+"@babel/template@npm:^7.22.15, @babel/template@npm:^7.26.9, @babel/template@npm:^7.3.3":
   version: 7.26.9
   resolution: "@babel/template@npm:7.26.9"
   dependencies:
@@ -1521,24 +1362,6 @@ __metadata:
     "@babel/parser": ^7.26.9
     "@babel/types": ^7.26.9
   checksum: 32259298c775e543ab994daff0c758b3d6a184349b146d6497aa46cec5907bc47a6bc09e7295a81a5eccfbd023d4811a9777cb5d698d582d09a87cabf5b576e7
-  languageName: node
-  linkType: hard
-
-"@babel/traverse@npm:^7.23.5":
-  version: 7.23.5
-  resolution: "@babel/traverse@npm:7.23.5"
-  dependencies:
-    "@babel/code-frame": ^7.23.5
-    "@babel/generator": ^7.23.5
-    "@babel/helper-environment-visitor": ^7.22.20
-    "@babel/helper-function-name": ^7.23.0
-    "@babel/helper-hoist-variables": ^7.22.5
-    "@babel/helper-split-export-declaration": ^7.22.6
-    "@babel/parser": ^7.23.5
-    "@babel/types": ^7.23.5
-    debug: ^4.1.0
-    globals: ^11.1.0
-  checksum: 0558b05360850c3ad6384e85bd55092126a8d5f93e29a8e227dd58fa1f9e1a4c25fd337c07c7ae509f0983e7a2b1e761ffdcfaa77a1e1bedbc867058e1de5a7d
   languageName: node
   linkType: hard
 
@@ -1557,18 +1380,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.22.15, @babel/types@npm:^7.22.19, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.23.5, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
-  version: 7.23.5
-  resolution: "@babel/types@npm:7.23.5"
-  dependencies:
-    "@babel/helper-string-parser": ^7.23.4
-    "@babel/helper-validator-identifier": ^7.22.20
-    to-fast-properties: ^2.0.0
-  checksum: 3d21774480a459ef13b41c2e32700d927af649e04b70c5d164814d8e04ab584af66a93330602c2925e1a6925c2b829cc153418a613a4e7d79d011be1f29ad4b2
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.20.7, @babel/types@npm:^7.25.9, @babel/types@npm:^7.26.9":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.22.15, @babel/types@npm:^7.22.19, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.25.9, @babel/types@npm:^7.26.9, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.26.9
   resolution: "@babel/types@npm:7.26.9"
   dependencies:
@@ -2345,18 +2157,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.0, @jridgewell/gen-mapping@npm:^0.3.2":
-  version: 0.3.3
-  resolution: "@jridgewell/gen-mapping@npm:0.3.3"
-  dependencies:
-    "@jridgewell/set-array": ^1.0.1
-    "@jridgewell/sourcemap-codec": ^1.4.10
-    "@jridgewell/trace-mapping": ^0.3.9
-  checksum: 4a74944bd31f22354fc01c3da32e83c19e519e3bbadafa114f6da4522ea77dd0c2842607e923a591d60a76699d819a2fbb6f3552e277efdb9b58b081390b60ab
-  languageName: node
-  linkType: hard
-
-"@jridgewell/gen-mapping@npm:^0.3.5":
+"@jridgewell/gen-mapping@npm:^0.3.0, @jridgewell/gen-mapping@npm:^0.3.5":
   version: 0.3.8
   resolution: "@jridgewell/gen-mapping@npm:0.3.8"
   dependencies:
@@ -2374,13 +2175,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/set-array@npm:^1.0.1":
-  version: 1.1.2
-  resolution: "@jridgewell/set-array@npm:1.1.2"
-  checksum: 69a84d5980385f396ff60a175f7177af0b8da4ddb81824cb7016a9ef914eee9806c72b6b65942003c63f7983d4f39a5c6c27185bbca88eb4690b62075602e28e
-  languageName: node
-  linkType: hard
-
 "@jridgewell/set-array@npm:^1.2.1":
   version: 1.2.1
   resolution: "@jridgewell/set-array@npm:1.2.1"
@@ -2395,17 +2189,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.17, @jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.9":
-  version: 0.3.20
-  resolution: "@jridgewell/trace-mapping@npm:0.3.20"
-  dependencies:
-    "@jridgewell/resolve-uri": ^3.1.0
-    "@jridgewell/sourcemap-codec": ^1.4.14
-  checksum: cd1a7353135f385909468ff0cf20bdd37e59f2ee49a13a966dedf921943e222082c583ade2b579ff6cd0d8faafcb5461f253e1bf2a9f48fec439211fdbe788f5
-  languageName: node
-  linkType: hard
-
-"@jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25":
+"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25, @jridgewell/trace-mapping@npm:^0.3.9":
   version: 0.3.25
   resolution: "@jridgewell/trace-mapping@npm:0.3.25"
   dependencies:
@@ -2452,19 +2236,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/auto-changelog@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@metamask/auto-changelog@npm:4.0.0"
+"@metamask/auto-changelog@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@metamask/auto-changelog@npm:6.1.0"
   dependencies:
+    "@octokit/rest": ^20.0.0
     diff: ^5.0.0
     execa: ^5.1.1
     semver: ^7.3.5
     yargs: ^17.0.1
   peerDependencies:
+    oxfmt: ^0.45.0
     prettier: ">=3.0.0"
+  peerDependenciesMeta:
+    oxfmt:
+      optional: true
+    prettier:
+      optional: true
   bin:
-    auto-changelog: dist/cli.js
-  checksum: 918275babb1dd5dfcb47e9a0d0e5e896ab0e6696d6cf67b7af9fce996d9d7db2d6117208f1ff8ad09588602e0829b76d3b0bdf5208975c77ec91b9c26854382d
+    auto-changelog: dist/cli.mjs
+  checksum: af543c8ceaa2f388dc3bdc088cd92070ed061e7a27ca7e2f2362feabea7b2657a465eda46f65b7b6a189de24df7696097b8f819c5bcab963b0d07bbf3ab642d7
   languageName: node
   linkType: hard
 
@@ -2478,7 +2269,7 @@ __metadata:
     "@babel/preset-typescript": ^7.23.3
     "@lavamoat/allow-scripts": ^3.1.0
     "@metamask/action-utils": ^1.0.0
-    "@metamask/auto-changelog": ^4.0.0
+    "@metamask/auto-changelog": ^6.1.0
     "@metamask/eslint-config": ^10.0.0
     "@metamask/eslint-config-jest": ^10.0.0
     "@metamask/eslint-config-nodejs": ^10.0.0
@@ -2765,6 +2556,131 @@ __metadata:
     node-gyp: ^10.0.0
     which: ^4.0.0
   checksum: c44d6874cffb0a2f6d947e230083b605b6f253450e24aa185ef28391dc366b10807cd4ca113fe367057b8b5310add36391894f9d782af15424830658ee386dfb
+  languageName: node
+  linkType: hard
+
+"@octokit/auth-token@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@octokit/auth-token@npm:4.0.0"
+  checksum: d78f4dc48b214d374aeb39caec4fdbf5c1e4fd8b9fcb18f630b1fe2cbd5a880fca05445f32b4561f41262cb551746aeb0b49e89c95c6dd99299706684d0cae2f
+  languageName: node
+  linkType: hard
+
+"@octokit/core@npm:^5.0.2":
+  version: 5.2.2
+  resolution: "@octokit/core@npm:5.2.2"
+  dependencies:
+    "@octokit/auth-token": ^4.0.0
+    "@octokit/graphql": ^7.1.0
+    "@octokit/request": ^8.4.1
+    "@octokit/request-error": ^5.1.1
+    "@octokit/types": ^13.0.0
+    before-after-hook: ^2.2.0
+    universal-user-agent: ^6.0.0
+  checksum: d4303d808c6b8eca32ce03381db5f6230440c1c6cfd9d73376ed583973094abd8ca56d9a64d490e6b0045f827a8f913b619bd90eae99c2cba682487720dc8002
+  languageName: node
+  linkType: hard
+
+"@octokit/endpoint@npm:^9.0.6":
+  version: 9.0.6
+  resolution: "@octokit/endpoint@npm:9.0.6"
+  dependencies:
+    "@octokit/types": ^13.1.0
+    universal-user-agent: ^6.0.0
+  checksum: f853c08f0777a8cc7c3d2509835d478e11a76d722f807d4f2ad7c0e64bf4dd159536409f466b367a907886aa3b78574d3d09ed95ac462c769e4fccaaad81e72a
+  languageName: node
+  linkType: hard
+
+"@octokit/graphql@npm:^7.1.0":
+  version: 7.1.1
+  resolution: "@octokit/graphql@npm:7.1.1"
+  dependencies:
+    "@octokit/request": ^8.4.1
+    "@octokit/types": ^13.0.0
+    universal-user-agent: ^6.0.0
+  checksum: afb60d5dda6d365334480540610d67b0c5f8e3977dd895fe504ce988f8b7183f29f3b16b88d895a701a739cf29d157d49f8f9fbc71b6c57eb4fc9bd97e099f55
+  languageName: node
+  linkType: hard
+
+"@octokit/openapi-types@npm:^24.2.0":
+  version: 24.2.0
+  resolution: "@octokit/openapi-types@npm:24.2.0"
+  checksum: 3c2d2f4cafd21c8a1e6a6fe6b56df6a3c09bc52ab6f829c151f9397694d028aa183ae856f08e006ee7ecaa7bd7eb413a903fbc0ffa6403e7b284ddcda20b1294
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-paginate-rest@npm:11.4.4-cjs.2":
+  version: 11.4.4-cjs.2
+  resolution: "@octokit/plugin-paginate-rest@npm:11.4.4-cjs.2"
+  dependencies:
+    "@octokit/types": ^13.7.0
+  peerDependencies:
+    "@octokit/core": 5
+  checksum: e6d1f4da255d08c24188b5df1436f22680e7fe2608d3af5d2f08a98f40d565bd3df0c58d306f05caae923247fffe861ec12d5f1273a882333fcdb34255e6c8b0
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-request-log@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@octokit/plugin-request-log@npm:4.0.1"
+  peerDependencies:
+    "@octokit/core": 5
+  checksum: fd8c0a201490cba00084689a0d1d54fc7b5ab5b6bdb7e447056b947b1754f78526e9685400eab10d3522bfa7b5bc49c555f41ec412c788610b96500b168f3789
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-rest-endpoint-methods@npm:13.3.2-cjs.1":
+  version: 13.3.2-cjs.1
+  resolution: "@octokit/plugin-rest-endpoint-methods@npm:13.3.2-cjs.1"
+  dependencies:
+    "@octokit/types": ^13.8.0
+  peerDependencies:
+    "@octokit/core": ^5
+  checksum: de38a7fe33aa41ecfa62dd8546d9b603cf43b1a6cf3a31e8c1950684e1cf0f9dc7ccbcff8ef570e825729f3800f42e6ae33447c836dfa12259391ced421df64f
+  languageName: node
+  linkType: hard
+
+"@octokit/request-error@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "@octokit/request-error@npm:5.1.1"
+  dependencies:
+    "@octokit/types": ^13.1.0
+    deprecation: ^2.0.0
+    once: ^1.4.0
+  checksum: 17d0b3f59c2a8a285715bfe6a85168d9c417aa7a0ff553b9be4198a3bc8bb00384a3530221a448eb19f8f07ea9fc48d264869624f5f84fa63a948a7af8cddc8c
+  languageName: node
+  linkType: hard
+
+"@octokit/request@npm:^8.4.1":
+  version: 8.4.1
+  resolution: "@octokit/request@npm:8.4.1"
+  dependencies:
+    "@octokit/endpoint": ^9.0.6
+    "@octokit/request-error": ^5.1.1
+    "@octokit/types": ^13.1.0
+    universal-user-agent: ^6.0.0
+  checksum: 0ba76728583543baeef9fda98690bc86c57e0a3ccac8c189d2b7d144d248c89167eb37a071ed8fead8f4da0a1c55c4dd98a8fc598769c263b95179fb200959de
+  languageName: node
+  linkType: hard
+
+"@octokit/rest@npm:^20.0.0":
+  version: 20.1.2
+  resolution: "@octokit/rest@npm:20.1.2"
+  dependencies:
+    "@octokit/core": ^5.0.2
+    "@octokit/plugin-paginate-rest": 11.4.4-cjs.2
+    "@octokit/plugin-request-log": ^4.0.0
+    "@octokit/plugin-rest-endpoint-methods": 13.3.2-cjs.1
+  checksum: 72309dd393f3424f0c4213d045332c1c1a00893bea4db9b54d6add7316d9a9b461932de3afe3c866bff52cc084c79e98f644dabd386cda95068690cc9ae97456
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^13.0.0, @octokit/types@npm:^13.1.0, @octokit/types@npm:^13.7.0, @octokit/types@npm:^13.8.0":
+  version: 13.10.0
+  resolution: "@octokit/types@npm:13.10.0"
+  dependencies:
+    "@octokit/openapi-types": ^24.2.0
+  checksum: fca3764548d5872535b9025c3b5fe6373fe588b287cb5b5259364796c1931bbe5e9ab8a86a5274ce43bb2b3e43b730067c3b86b6b1ade12a98cd59b2e8b3610d
   languageName: node
   linkType: hard
 
@@ -3119,20 +3035,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/babel__core@npm:^7.1.14":
-  version: 7.1.19
-  resolution: "@types/babel__core@npm:7.1.19"
-  dependencies:
-    "@babel/parser": ^7.1.0
-    "@babel/types": ^7.0.0
-    "@types/babel__generator": "*"
-    "@types/babel__template": "*"
-    "@types/babel__traverse": "*"
-  checksum: 8c9fa87a1c2224cbec251683a58bebb0d74c497118034166aaa0491a4e2627998a6621fc71f8a60ffd27d9c0c52097defedf7637adc6618d0331c15adb302338
-  languageName: node
-  linkType: hard
-
-"@types/babel__core@npm:^7.20.5":
+"@types/babel__core@npm:^7.1.14, @types/babel__core@npm:^7.20.5":
   version: 7.20.5
   resolution: "@types/babel__core@npm:7.20.5"
   dependencies:
@@ -3192,21 +3095,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/debug@npm:^4.0.0":
+"@types/debug@npm:^4.0.0, @types/debug@npm:^4.1.7":
   version: 4.1.12
   resolution: "@types/debug@npm:4.1.12"
   dependencies:
     "@types/ms": "*"
   checksum: 47876a852de8240bfdaf7481357af2b88cb660d30c72e73789abf00c499d6bc7cd5e52f41c915d1b9cd8ec9fef5b05688d7b7aef17f7f272c2d04679508d1053
-  languageName: node
-  linkType: hard
-
-"@types/debug@npm:^4.1.7":
-  version: 4.1.7
-  resolution: "@types/debug@npm:4.1.7"
-  dependencies:
-    "@types/ms": "*"
-  checksum: 0a7b89d8ed72526858f0b61c6fd81f477853e8c4415bb97f48b1b5545248d2ae389931680b94b393b993a7cfe893537a200647d93defe6d87159b96812305adc
   languageName: node
   linkType: hard
 
@@ -3781,15 +3675,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "ansi-styles@npm:3.2.1"
-  dependencies:
-    color-convert: ^1.9.0
-  checksum: d85ade01c10e5dd77b6c89f34ed7531da5830d2cb5882c645f330079975b716438cd7ebb81d0d6e6b4f9c577f19ae41ab55f07f19786b02f9dfd9e0377395665
-  languageName: node
-  linkType: hard
-
 "ansi-styles@npm:^4.0.0, ansi-styles@npm:^4.1.0":
   version: 4.3.0
   resolution: "ansi-styles@npm:4.3.0"
@@ -3873,20 +3758,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-includes@npm:^3.1.4":
-  version: 3.1.5
-  resolution: "array-includes@npm:3.1.5"
-  dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.4
-    es-abstract: ^1.19.5
-    get-intrinsic: ^1.1.1
-    is-string: ^1.0.7
-  checksum: f6f24d834179604656b7bec3e047251d5cc87e9e87fab7c175c61af48e80e75acd296017abcde21fb52292ab6a2a449ab2ee37213ee48c8709f004d75983f9c5
-  languageName: node
-  linkType: hard
-
-"array-includes@npm:^3.1.6, array-includes@npm:^3.1.8":
+"array-includes@npm:^3.1.4, array-includes@npm:^3.1.6, array-includes@npm:^3.1.8":
   version: 3.1.9
   resolution: "array-includes@npm:3.1.9"
   dependencies:
@@ -3923,19 +3795,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.flat@npm:^1.2.5":
-  version: 1.3.0
-  resolution: "array.prototype.flat@npm:1.3.0"
-  dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.3
-    es-abstract: ^1.19.2
-    es-shim-unscopables: ^1.0.0
-  checksum: 2a652b3e8dc0bebb6117e42a5ab5738af0203a14c27341d7bb2431467bdb4b348e2c5dc555dfcda8af0a5e4075c400b85311ded73861c87290a71a17c3e0a257
-  languageName: node
-  linkType: hard
-
-"array.prototype.flat@npm:^1.3.1":
+"array.prototype.flat@npm:^1.2.5, array.prototype.flat@npm:^1.3.1":
   version: 1.3.3
   resolution: "array.prototype.flat@npm:1.3.3"
   dependencies:
@@ -4136,6 +3996,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"before-after-hook@npm:^2.2.0":
+  version: 2.2.3
+  resolution: "before-after-hook@npm:2.2.3"
+  checksum: a1a2430976d9bdab4cd89cb50d27fa86b19e2b41812bf1315923b0cba03371ebca99449809226425dd3bcef20e010db61abdaff549278e111d6480034bebae87
+  languageName: node
+  linkType: hard
+
 "bin-links@npm:4.0.4":
   version: 4.0.4
   resolution: "bin-links@npm:4.0.4"
@@ -4196,21 +4063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.21.9, browserslist@npm:^4.22.2":
-  version: 4.22.2
-  resolution: "browserslist@npm:4.22.2"
-  dependencies:
-    caniuse-lite: ^1.0.30001565
-    electron-to-chromium: ^1.4.601
-    node-releases: ^2.0.14
-    update-browserslist-db: ^1.0.13
-  bin:
-    browserslist: cli.js
-  checksum: 33ddfcd9145220099a7a1ac533cecfe5b7548ffeb29b313e1b57be6459000a1f8fa67e781cf4abee97268ac594d44134fcc4a6b2b4750ceddc9796e3a22076d9
-  languageName: node
-  linkType: hard
-
-"browserslist@npm:^4.24.0":
+"browserslist@npm:^4.22.2, browserslist@npm:^4.24.0":
   version: 4.24.4
   resolution: "browserslist@npm:4.24.4"
   dependencies:
@@ -4312,16 +4165,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind@npm:^1.0.0, call-bind@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "call-bind@npm:1.0.2"
-  dependencies:
-    function-bind: ^1.1.1
-    get-intrinsic: ^1.0.2
-  checksum: f8e31de9d19988a4b80f3e704788c4a2d6b6f3d17cfec4f57dc29ced450c53a49270dc66bf0fbd693329ee948dd33e6c90a329519aef17474a4d961e8d6426b0
-  languageName: node
-  linkType: hard
-
 "call-bind@npm:^1.0.7, call-bind@npm:^1.0.8":
   version: 1.0.8
   resolution: "call-bind@npm:1.0.8"
@@ -4334,17 +4177,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bound@npm:^1.0.2":
-  version: 1.0.3
-  resolution: "call-bound@npm:1.0.3"
-  dependencies:
-    call-bind-apply-helpers: ^1.0.1
-    get-intrinsic: ^1.2.6
-  checksum: a93bbe0f2d0a2d6c144a4349ccd0593d5d0d5d9309b69101710644af8964286420062f2cc3114dca120b9bc8cc07507952d4b1b3ea7672e0d7f6f1675efedb32
-  languageName: node
-  linkType: hard
-
-"call-bound@npm:^1.0.3, call-bound@npm:^1.0.4":
+"call-bound@npm:^1.0.2, call-bound@npm:^1.0.3, call-bound@npm:^1.0.4":
   version: 1.0.4
   resolution: "call-bound@npm:1.0.4"
   dependencies:
@@ -4375,13 +4208,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001565":
-  version: 1.0.30001566
-  resolution: "caniuse-lite@npm:1.0.30001566"
-  checksum: 0f9084bf9f7d5c0a9ddb200c2baddb25dd2ad5a2f205f01e7b971f3e98e9a7bb23c2d86bae48237e9bc9782b682cffaaf3406d936937ab9844987dbe2a6401f2
-  languageName: node
-  linkType: hard
-
 "caniuse-lite@npm:^1.0.30001688":
   version: 1.0.30001700
   resolution: "caniuse-lite@npm:1.0.30001700"
@@ -4393,17 +4219,6 @@ __metadata:
   version: 2.0.1
   resolution: "ccount@npm:2.0.1"
   checksum: 48193dada54c9e260e0acf57fc16171a225305548f9ad20d5471e0f7a8c026aedd8747091dccb0d900cde7df4e4ddbd235df0d8de4a64c71b12f0d3303eeafd4
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^2.4.2":
-  version: 2.4.2
-  resolution: "chalk@npm:2.4.2"
-  dependencies:
-    ansi-styles: ^3.2.1
-    escape-string-regexp: ^1.0.5
-    supports-color: ^5.3.0
-  checksum: ec3661d38fe77f681200f878edbd9448821924e0f93a9cefc0e26a33b145f1027a2084bf19967160d11e1f03bfe4eaffcabf5493b89098b2782c3fe0b03d80c2
   languageName: node
   linkType: hard
 
@@ -4526,28 +4341,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-convert@npm:^1.9.0":
-  version: 1.9.3
-  resolution: "color-convert@npm:1.9.3"
-  dependencies:
-    color-name: 1.1.3
-  checksum: fd7a64a17cde98fb923b1dd05c5f2e6f7aefda1b60d67e8d449f9328b4e53b228a428fd38bfeaeb2db2ff6b6503a776a996150b80cdf224062af08a5c8a3a203
-  languageName: node
-  linkType: hard
-
 "color-convert@npm:^2.0.1":
   version: 2.0.1
   resolution: "color-convert@npm:2.0.1"
   dependencies:
     color-name: ~1.1.4
   checksum: 79e6bdb9fd479a205c71d89574fccfb22bd9053bd98c6c4d870d65c132e5e904e6034978e55b43d69fcaa7433af2016ee203ce76eeba9cfa554b373e7f7db336
-  languageName: node
-  linkType: hard
-
-"color-name@npm:1.1.3":
-  version: 1.1.3
-  resolution: "color-name@npm:1.1.3"
-  checksum: 09c5d3e33d2105850153b14466501f2bfb30324a2f76568a408763a3b7433b0e50e5b4ab1947868e65cb101bb7cb75029553f2c333b6d4b8138a73fcc133d69d
   languageName: node
   linkType: hard
 
@@ -4743,15 +4542,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
-  version: 4.3.4
-  resolution: "debug@npm:4.3.4"
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
+  version: 4.4.0
+  resolution: "debug@npm:4.4.0"
   dependencies:
-    ms: 2.1.2
+    ms: ^2.1.3
   peerDependenciesMeta:
     supports-color:
       optional: true
-  checksum: 3dbad3f94ea64f34431a9cbf0bafb61853eda57bff2880036153438f50fb5a84f27683ba0d8e5426bf41a8c6ff03879488120cf5b3a761e77953169c0600a708
+  checksum: fb42df878dd0e22816fc56e1fdca9da73caa85212fbe40c868b1295a6878f9101ae684f4eeef516c13acfc700f5ea07f1136954f43d4cd2d477a811144136479
   languageName: node
   linkType: hard
 
@@ -4761,18 +4560,6 @@ __metadata:
   dependencies:
     ms: ^2.1.1
   checksum: b3d8c5940799914d30314b7c3304a43305fd0715581a919dacb8b3176d024a782062368405b47491516d2091d6462d4d11f2f4974a405048094f8bfebfa3071c
-  languageName: node
-  linkType: hard
-
-"debug@npm:^4.0.0, debug@npm:^4.3.1":
-  version: 4.4.0
-  resolution: "debug@npm:4.4.0"
-  dependencies:
-    ms: ^2.1.3
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: fb42df878dd0e22816fc56e1fdca9da73caa85212fbe40c868b1295a6878f9101ae684f4eeef516c13acfc700f5ea07f1136954f43d4cd2d477a811144136479
   languageName: node
   linkType: hard
 
@@ -4846,17 +4633,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"define-properties@npm:^1.1.3, define-properties@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "define-properties@npm:1.1.4"
-  dependencies:
-    has-property-descriptors: ^1.0.0
-    object-keys: ^1.1.1
-  checksum: ce0aef3f9eb193562b5cfb79b2d2c86b6a109dfc9fdcb5f45d680631a1a908c06824ddcdb72b7573b54e26ace07f0a23420aaba0d5c627b34d2c1de8ef527e2b
-  languageName: node
-  linkType: hard
-
-"define-properties@npm:^1.2.1":
+"define-properties@npm:^1.1.3, define-properties@npm:^1.2.1":
   version: 1.2.1
   resolution: "define-properties@npm:1.2.1"
   dependencies:
@@ -4885,6 +4662,13 @@ __metadata:
   version: 1.1.2
   resolution: "depd@npm:1.1.2"
   checksum: 6b406620d269619852885ce15965272b829df6f409724415e0002c8632ab6a8c0a08ec1f0bd2add05dc7bd7507606f7e2cc034fa24224ab829580040b835ecd9
+  languageName: node
+  linkType: hard
+
+"deprecation@npm:^2.0.0":
+  version: 2.3.1
+  resolution: "deprecation@npm:2.3.1"
+  checksum: f56a05e182c2c195071385455956b0c4106fe14e36245b00c689ceef8e8ab639235176a96977ba7c74afb173317fac2e0ec6ec7a1c6d1e6eaa401c586c714132
   languageName: node
   linkType: hard
 
@@ -5004,13 +4788,6 @@ __metadata:
   version: 1.1.1
   resolution: "ee-first@npm:1.1.1"
   checksum: 1b4cac778d64ce3b582a7e26b218afe07e207a0f9bfe13cc7395a6d307849cfe361e65033c3251e00c27dd060cab43014c2d6b2647676135e18b77d2d05b3f4f
-  languageName: node
-  linkType: hard
-
-"electron-to-chromium@npm:^1.4.601":
-  version: 1.4.605
-  resolution: "electron-to-chromium@npm:1.4.605"
-  checksum: 2d42afd5d8cfc053d68944891f02fb007931fae85c0a19bc4f458bb3430e793b8a76664b058e1b06ab99e784f73e4c6b56493eaede2ff6012dbcaf8781fec4a7
   languageName: node
   linkType: hard
 
@@ -5160,37 +4937,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.19.0, es-abstract@npm:^1.19.1, es-abstract@npm:^1.19.2, es-abstract@npm:^1.19.5":
-  version: 1.20.1
-  resolution: "es-abstract@npm:1.20.1"
-  dependencies:
-    call-bind: ^1.0.2
-    es-to-primitive: ^1.2.1
-    function-bind: ^1.1.1
-    function.prototype.name: ^1.1.5
-    get-intrinsic: ^1.1.1
-    get-symbol-description: ^1.0.0
-    has: ^1.0.3
-    has-property-descriptors: ^1.0.0
-    has-symbols: ^1.0.3
-    internal-slot: ^1.0.3
-    is-callable: ^1.2.4
-    is-negative-zero: ^2.0.2
-    is-regex: ^1.1.4
-    is-shared-array-buffer: ^1.0.2
-    is-string: ^1.0.7
-    is-weakref: ^1.0.2
-    object-inspect: ^1.12.0
-    object-keys: ^1.1.1
-    object.assign: ^4.1.2
-    regexp.prototype.flags: ^1.4.3
-    string.prototype.trimend: ^1.0.5
-    string.prototype.trimstart: ^1.0.5
-    unbox-primitive: ^1.0.2
-  checksum: 28da27ae0ed9c76df7ee8ef5c278df79dcfdb554415faf7068bb7c58f8ba8e2a16bfb59e586844be6429ab4c302ca7748979d48442224cb1140b051866d74b7f
-  languageName: node
-  linkType: hard
-
 "es-define-property@npm:^1.0.0, es-define-property@npm:^1.0.1":
   version: 1.0.1
   resolution: "es-define-property@npm:1.0.1"
@@ -5250,32 +4996,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-shim-unscopables@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "es-shim-unscopables@npm:1.0.0"
-  dependencies:
-    has: ^1.0.3
-  checksum: 83e95cadbb6ee44d3644dfad60dcad7929edbc42c85e66c3e99aefd68a3a5c5665f2686885cddb47dfeabfd77bd5ea5a7060f2092a955a729bbd8834f0d86fa1
-  languageName: node
-  linkType: hard
-
 "es-shim-unscopables@npm:^1.0.2":
   version: 1.1.0
   resolution: "es-shim-unscopables@npm:1.1.0"
   dependencies:
     hasown: ^2.0.2
   checksum: 33cfb1ebcb2f869f0bf528be1a8660b4fe8b6cec8fc641f330e508db2284b58ee2980fad6d0828882d22858c759c0806076427a3673b6daa60f753e3b558ee15
-  languageName: node
-  linkType: hard
-
-"es-to-primitive@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "es-to-primitive@npm:1.2.1"
-  dependencies:
-    is-callable: ^1.1.4
-    is-date-object: ^1.0.1
-    is-symbol: ^1.0.2
-  checksum: 4ead6671a2c1402619bdd77f3503991232ca15e17e46222b0a41a5d81aebc8740a77822f5b3c965008e631153e9ef0580540007744521e72de8e33599fca2eed
   languageName: node
   linkType: hard
 
@@ -5453,14 +5179,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escalade@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "escalade@npm:3.1.1"
-  checksum: a3e2a99f07acb74b3ad4989c48ca0c3140f69f923e56d0cba0526240ee470b91010f9d39001f2a4a313841d237ede70a729e92125191ba5d21e74b106800b133
-  languageName: node
-  linkType: hard
-
-"escalade@npm:^3.2.0":
+"escalade@npm:^3.1.1, escalade@npm:^3.2.0":
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
   checksum: 47b029c83de01b0d17ad99ed766347b974b0d628e848de404018f3abee728e987da0d2d370ad4574aa3d5b5bfc368754fd085d69a30f8e75903486ec4b5b709e
@@ -6176,18 +5895,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"function.prototype.name@npm:^1.1.5":
-  version: 1.1.5
-  resolution: "function.prototype.name@npm:1.1.5"
-  dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.3
-    es-abstract: ^1.19.0
-    functions-have-names: ^1.2.2
-  checksum: acd21d733a9b649c2c442f067567743214af5fa248dbeee69d8278ce7df3329ea5abac572be9f7470b4ec1cd4d8f1040e3c5caccf98ebf2bf861a0deab735c27
-  languageName: node
-  linkType: hard
-
 "function.prototype.name@npm:^1.1.6, function.prototype.name@npm:^1.1.8":
   version: 1.1.8
   resolution: "function.prototype.name@npm:1.1.8"
@@ -6202,7 +5909,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"functions-have-names@npm:^1.2.2, functions-have-names@npm:^1.2.3":
+"functions-have-names@npm:^1.2.3":
   version: 1.2.3
   resolution: "functions-have-names@npm:1.2.3"
   checksum: c3f1f5ba20f4e962efb71344ce0a40722163e85bee2101ce25f88214e78182d2d2476aa85ef37950c579eb6cf6ee811c17b3101bb84004bb75655f3e33f3fdb5
@@ -6246,18 +5953,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.0.2, get-intrinsic@npm:^1.1.0, get-intrinsic@npm:^1.1.1":
-  version: 1.1.2
-  resolution: "get-intrinsic@npm:1.1.2"
-  dependencies:
-    function-bind: ^1.1.1
-    has: ^1.0.3
-    has-symbols: ^1.0.3
-  checksum: 252f45491f2ba88ebf5b38018020c7cc3279de54b1d67ffb70c0cdf1dfa8ab31cd56467b5d117a8b4275b7a4dde91f86766b163a17a850f036528a7b2faafb2b
-  languageName: node
-  linkType: hard
-
-"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
+"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
   version: 1.3.1
   resolution: "get-intrinsic@npm:1.3.1"
   dependencies:
@@ -6275,24 +5971,6 @@ __metadata:
     hasown: ^2.0.2
     math-intrinsics: ^1.1.0
   checksum: c02b3b6a445f9cd53e14896303794ac60f9751f58a69099127248abdb0251957174c6524245fc68579dc8e6a35161d3d94c93e665f808274716f4248b269436a
-  languageName: node
-  linkType: hard
-
-"get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6":
-  version: 1.2.7
-  resolution: "get-intrinsic@npm:1.2.7"
-  dependencies:
-    call-bind-apply-helpers: ^1.0.1
-    es-define-property: ^1.0.1
-    es-errors: ^1.3.0
-    es-object-atoms: ^1.0.0
-    function-bind: ^1.1.2
-    get-proto: ^1.0.0
-    gopd: ^1.2.0
-    has-symbols: ^1.1.0
-    hasown: ^2.0.2
-    math-intrinsics: ^1.1.0
-  checksum: a1597b3b432074f805b6a0ba1182130dd6517c0ea0c4eecc4b8834c803913e1ea62dfc412865be795b3dacb1555a21775b70cf9af7a18b1454ff3414e5442d4a
   languageName: node
   linkType: hard
 
@@ -6331,16 +6009,6 @@ __metadata:
   version: 8.0.1
   resolution: "get-stream@npm:8.0.1"
   checksum: 01e3d3cf29e1393f05f44d2f00445c5f9ec3d1c49e8179b31795484b9c117f4c695e5e07b88b50785d5c8248a788c85d9913a79266fc77e3ef11f78f10f1b974
-  languageName: node
-  linkType: hard
-
-"get-symbol-description@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "get-symbol-description@npm:1.0.0"
-  dependencies:
-    call-bind: ^1.0.2
-    get-intrinsic: ^1.1.1
-  checksum: 9ceff8fe968f9270a37a1f73bf3f1f7bda69ca80f4f80850670e0e7b9444ff99323f7ac52f96567f8b5f5fbe7ac717a0d81d3407c7313e82810c6199446a5247
   languageName: node
   linkType: hard
 
@@ -6504,17 +6172,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.2.4":
+"graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: ac85f94da92d8eb6b7f5a8b20ce65e43d66761c55ce85ac96df6865308390da45a8d3f0296dd3a663de65d30ba497bd46c696cc1e248c72b13d6d567138a4fc7
-  languageName: node
-  linkType: hard
-
-"graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
-  version: 4.2.10
-  resolution: "graceful-fs@npm:4.2.10"
-  checksum: 3f109d70ae123951905d85032ebeae3c2a5a7a997430df00ea30df0e3a6c60cf6689b109654d6fdacd28810a053348c4d14642da1d075049e6be1ba5216218da
   languageName: node
   linkType: hard
 
@@ -6532,17 +6193,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-bigints@npm:^1.0.1, has-bigints@npm:^1.0.2":
+"has-bigints@npm:^1.0.2":
   version: 1.0.2
   resolution: "has-bigints@npm:1.0.2"
   checksum: 390e31e7be7e5c6fe68b81babb73dfc35d413604d7ee5f56da101417027a4b4ce6a27e46eff97ad040c835b5d228676eae99a9b5c3bc0e23c8e81a49241ff45b
-  languageName: node
-  linkType: hard
-
-"has-flag@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "has-flag@npm:3.0.0"
-  checksum: 4a15638b454bf086c8148979aae044dd6e39d63904cd452d970374fa6a87623423da485dfb814e7be882e05c096a7ccf1ebd48e7e7501d0208d8384ff4dea73b
   languageName: node
   linkType: hard
 
@@ -6553,16 +6207,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-property-descriptors@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "has-property-descriptors@npm:1.0.0"
-  dependencies:
-    get-intrinsic: ^1.1.1
-  checksum: a6d3f0a266d0294d972e354782e872e2fe1b6495b321e6ef678c9b7a06a40408a6891817350c62e752adced73a94ac903c54734fee05bf65b1905ee1368194bb
-  languageName: node
-  linkType: hard
-
-"has-property-descriptors@npm:^1.0.2":
+"has-property-descriptors@npm:^1.0.0, has-property-descriptors@npm:^1.0.2":
   version: 1.0.2
   resolution: "has-property-descriptors@npm:1.0.2"
   dependencies:
@@ -6580,26 +6225,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-symbols@npm:^1.0.1, has-symbols@npm:^1.0.2, has-symbols@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "has-symbols@npm:1.0.3"
-  checksum: a054c40c631c0d5741a8285010a0777ea0c068f99ed43e5d6eb12972da223f8af553a455132fdb0801bdcfa0e0f443c0c03a68d8555aa529b3144b446c3f2410
-  languageName: node
-  linkType: hard
-
-"has-symbols@npm:^1.1.0":
+"has-symbols@npm:^1.0.3, has-symbols@npm:^1.1.0":
   version: 1.1.0
   resolution: "has-symbols@npm:1.1.0"
   checksum: b2316c7302a0e8ba3aaba215f834e96c22c86f192e7310bdf689dd0e6999510c89b00fbc5742571507cebf25764d68c988b3a0da217369a73596191ac0ce694b
-  languageName: node
-  linkType: hard
-
-"has-tostringtag@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "has-tostringtag@npm:1.0.0"
-  dependencies:
-    has-symbols: ^1.0.2
-  checksum: cc12eb28cb6ae22369ebaad3a8ab0799ed61270991be88f208d508076a1e99abe4198c965935ce85ea90b60c94ddda73693b0920b58e7ead048b4a391b502c1c
   languageName: node
   linkType: hard
 
@@ -6628,16 +6257,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hasown@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "hasown@npm:2.0.0"
-  dependencies:
-    function-bind: ^1.1.2
-  checksum: 6151c75ca12554565098641c98a40f4cc86b85b0fd5b6fe92360967e4605a4f9610f7757260b4e8098dd1c2ce7f4b095f2006fe72a570e3b6d2d28de0298c176
-  languageName: node
-  linkType: hard
-
-"hasown@npm:^2.0.2":
+"hasown@npm:^2.0.0, hasown@npm:^2.0.2":
   version: 2.0.2
   resolution: "hasown@npm:2.0.2"
   dependencies:
@@ -6884,17 +6504,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"internal-slot@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "internal-slot@npm:1.0.3"
-  dependencies:
-    get-intrinsic: ^1.1.0
-    has: ^1.0.3
-    side-channel: ^1.0.4
-  checksum: 1944f92e981e47aebc98a88ff0db579fd90543d937806104d0b96557b10c1f170c51fb777b97740a8b6ddeec585fca8c39ae99fd08a8e058dfc8ab70937238bf
-  languageName: node
-  linkType: hard
-
 "internal-slot@npm:^1.1.0":
   version: 1.1.0
   resolution: "internal-slot@npm:1.1.0"
@@ -6971,31 +6580,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-bigint@npm:^1.0.1":
-  version: 1.0.4
-  resolution: "is-bigint@npm:1.0.4"
-  dependencies:
-    has-bigints: ^1.0.1
-  checksum: c56edfe09b1154f8668e53ebe8252b6f185ee852a50f9b41e8d921cb2bed425652049fbe438723f6cb48a63ca1aa051e948e7e401e093477c99c84eba244f666
-  languageName: node
-  linkType: hard
-
 "is-bigint@npm:^1.1.0":
   version: 1.1.0
   resolution: "is-bigint@npm:1.1.0"
   dependencies:
     has-bigints: ^1.0.2
   checksum: ee1544f0e664f253306786ed1dce494b8cf242ef415d6375d8545b4d8816b0f054bd9f948a8988ae2c6325d1c28260dd02978236b2f7b8fb70dfc4838a6c9fa7
-  languageName: node
-  linkType: hard
-
-"is-boolean-object@npm:^1.1.0":
-  version: 1.1.2
-  resolution: "is-boolean-object@npm:1.1.2"
-  dependencies:
-    call-bind: ^1.0.2
-    has-tostringtag: ^1.0.0
-  checksum: c03b23dbaacadc18940defb12c1c0e3aaece7553ef58b162a0f6bba0c2a7e1551b59f365b91e00d2dbac0522392d576ef322628cb1d036a0fe51eb466db67222
   languageName: node
   linkType: hard
 
@@ -7006,13 +6596,6 @@ __metadata:
     call-bound: ^1.0.3
     has-tostringtag: ^1.0.2
   checksum: 0415b181e8f1bfd5d3f8a20f8108e64d372a72131674eea9c2923f39d065b6ad08d654765553bdbffbd92c3746f1007986c34087db1bd89a31f71be8359ccdaa
-  languageName: node
-  linkType: hard
-
-"is-callable@npm:^1.1.4, is-callable@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "is-callable@npm:1.2.4"
-  checksum: 1a28d57dc435797dae04b173b65d6d1e77d4f16276e9eff973f994eadcfdc30a017e6a597f092752a083c1103cceb56c91e3dadc6692fedb9898dfaba701575f
   languageName: node
   linkType: hard
 
@@ -7040,15 +6623,6 @@ __metadata:
     get-intrinsic: ^1.2.6
     is-typed-array: ^1.1.13
   checksum: 31600dd19932eae7fd304567e465709ffbfa17fa236427c9c864148e1b54eb2146357fcf3aed9b686dee13c217e1bb5a649cb3b9c479e1004c0648e9febde1b2
-  languageName: node
-  linkType: hard
-
-"is-date-object@npm:^1.0.1":
-  version: 1.0.5
-  resolution: "is-date-object@npm:1.0.5"
-  dependencies:
-    has-tostringtag: ^1.0.0
-  checksum: baa9077cdf15eb7b58c79398604ca57379b2fc4cf9aa7a9b9e295278648f628c9b201400c01c5e0f7afae56507d741185730307cbe7cad3b9f90a77e5ee342fc
   languageName: node
   linkType: hard
 
@@ -7162,26 +6736,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-negative-zero@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "is-negative-zero@npm:2.0.2"
-  checksum: f3232194c47a549da60c3d509c9a09be442507616b69454716692e37ae9f37c4dea264fb208ad0c9f3efd15a796a46b79df07c7e53c6227c32170608b809149a
-  languageName: node
-  linkType: hard
-
 "is-negative-zero@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-negative-zero@npm:2.0.3"
   checksum: c1e6b23d2070c0539d7b36022d5a94407132411d01aba39ec549af824231f3804b1aea90b5e4e58e807a65d23ceb538ed6e355ce76b267bdd86edb757ffcbdcd
-  languageName: node
-  linkType: hard
-
-"is-number-object@npm:^1.0.4":
-  version: 1.0.7
-  resolution: "is-number-object@npm:1.0.7"
-  dependencies:
-    has-tostringtag: ^1.0.0
-  checksum: d1e8d01bb0a7134c74649c4e62da0c6118a0bfc6771ea3c560914d52a627873e6920dd0fd0ebc0e12ad2ff4687eac4c308f7e80320b973b2c8a2c8f97a7524f7
   languageName: node
   linkType: hard
 
@@ -7216,16 +6774,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-regex@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "is-regex@npm:1.1.4"
-  dependencies:
-    call-bind: ^1.0.2
-    has-tostringtag: ^1.0.0
-  checksum: 362399b33535bc8f386d96c45c9feb04cf7f8b41c182f54174c1a45c9abbbe5e31290bbad09a458583ff6bf3b2048672cdb1881b13289569a7c548370856a652
-  languageName: node
-  linkType: hard
-
 "is-regex@npm:^1.2.1":
   version: 1.2.1
   resolution: "is-regex@npm:1.2.1"
@@ -7242,15 +6790,6 @@ __metadata:
   version: 2.0.3
   resolution: "is-set@npm:2.0.3"
   checksum: 36e3f8c44bdbe9496c9689762cc4110f6a6a12b767c5d74c0398176aa2678d4467e3bf07595556f2dba897751bde1422480212b97d973c7b08a343100b0c0dfe
-  languageName: node
-  linkType: hard
-
-"is-shared-array-buffer@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "is-shared-array-buffer@npm:1.0.2"
-  dependencies:
-    call-bind: ^1.0.2
-  checksum: 9508929cf14fdc1afc9d61d723c6e8d34f5e117f0bffda4d97e7a5d88c3a8681f633a74f8e3ad1fe92d5113f9b921dc5ca44356492079612f9a247efbce7032a
   languageName: node
   linkType: hard
 
@@ -7277,15 +6816,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-string@npm:^1.0.5, is-string@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "is-string@npm:1.0.7"
-  dependencies:
-    has-tostringtag: ^1.0.0
-  checksum: 323b3d04622f78d45077cf89aab783b2f49d24dc641aa89b5ad1a72114cfeff2585efc8c12ef42466dff32bde93d839ad321b26884cf75e5a7892a938b089989
-  languageName: node
-  linkType: hard
-
 "is-string@npm:^1.1.1":
   version: 1.1.1
   resolution: "is-string@npm:1.1.1"
@@ -7293,15 +6823,6 @@ __metadata:
     call-bound: ^1.0.3
     has-tostringtag: ^1.0.2
   checksum: 2eeaaff605250f5e836ea3500d33d1a5d3aa98d008641d9d42fb941e929ffd25972326c2ef912987e54c95b6f10416281aaf1b35cdf81992cfb7524c5de8e193
-  languageName: node
-  linkType: hard
-
-"is-symbol@npm:^1.0.2, is-symbol@npm:^1.0.3":
-  version: 1.0.4
-  resolution: "is-symbol@npm:1.0.4"
-  dependencies:
-    has-symbols: ^1.0.2
-  checksum: 92805812ef590738d9de49d677cd17dfd486794773fb6fa0032d16452af46e9b91bb43ffe82c983570f015b37136f4b53b28b8523bfb10b0ece7a66c31a54510
   languageName: node
   linkType: hard
 
@@ -7332,16 +6853,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-weakref@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "is-weakref@npm:1.0.2"
-  dependencies:
-    call-bind: ^1.0.2
-  checksum: 95bd9a57cdcb58c63b1c401c60a474b0f45b94719c30f548c891860f051bc2231575c290a6b420c6bc6e7ed99459d424c652bd5bf9a1d5259505dc35b4bf83de
-  languageName: node
-  linkType: hard
-
-"is-weakref@npm:^1.1.1":
+"is-weakref@npm:^1.0.2, is-weakref@npm:^1.1.1":
   version: 1.1.1
   resolution: "is-weakref@npm:1.1.1"
   dependencies:
@@ -8000,15 +7512,6 @@ __metadata:
   version: 3.1.0
   resolution: "jsdoc-type-pratt-parser@npm:3.1.0"
   checksum: 2f437b57621f1e481918165f6cf0e48256628a9e510d8b3f88a2ab667bf2128bf8b94c628b57c43e78f555ca61983e9c282814703840dc091d2623992214a061
-  languageName: node
-  linkType: hard
-
-"jsesc@npm:^2.5.1":
-  version: 2.5.2
-  resolution: "jsesc@npm:2.5.2"
-  bin:
-    jsesc: bin/jsesc
-  checksum: 4dc190771129e12023f729ce20e1e0bfceac84d73a85bc3119f7f938843fe25a4aeccb54b6494dce26fcf263d815f5f31acdefac7cc9329efb8422a4f4d9fa9d
   languageName: node
   linkType: hard
 
@@ -9005,13 +8508,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:2.1.2":
-  version: 2.1.2
-  resolution: "ms@npm:2.1.2"
-  checksum: 673cdb2c3133eb050c745908d8ce632ed2c02d85640e2edb3ace856a2266a813b30c613569bf3354fdf4ea7d1a1494add3bfa95e2713baa27d0c2c71fc44f58f
-  languageName: node
-  linkType: hard
-
 "ms@npm:2.1.3, ms@npm:^2.0.0, ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
@@ -9026,16 +8522,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.4":
-  version: 3.3.4
-  resolution: "nanoid@npm:3.3.4"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 2fddd6dee994b7676f008d3ffa4ab16035a754f4bb586c61df5a22cf8c8c94017aadd360368f47d653829e0569a92b129979152ff97af23a558331e47e37cd9c
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.8":
+"nanoid@npm:^3.3.4, nanoid@npm:^3.3.8":
   version: 3.3.8
   resolution: "nanoid@npm:3.3.8"
   bin:
@@ -9109,13 +8596,6 @@ __metadata:
   version: 0.4.0
   resolution: "node-int64@npm:0.4.0"
   checksum: d0b30b1ee6d961851c60d5eaa745d30b5c95d94bc0e74b81e5292f7c42a49e3af87f1eb9e89f59456f80645d679202537de751b7d72e9e40ceea40c5e449057e
-  languageName: node
-  linkType: hard
-
-"node-releases@npm:^2.0.14":
-  version: 2.0.14
-  resolution: "node-releases@npm:2.0.14"
-  checksum: 59443a2f77acac854c42d321bf1b43dea0aef55cd544c6a686e9816a697300458d4e82239e2d794ea05f7bbbc8a94500332e2d3ac3f11f52e4b16cbe638b3c41
   languageName: node
   linkType: hard
 
@@ -9243,13 +8723,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-inspect@npm:^1.12.0, object-inspect@npm:^1.9.0":
-  version: 1.12.2
-  resolution: "object-inspect@npm:1.12.2"
-  checksum: a534fc1b8534284ed71f25ce3a496013b7ea030f3d1b77118f6b7b1713829262be9e6243acbcb3ef8c626e2b64186112cb7f6db74e37b2789b9c789ca23048b2
-  languageName: node
-  linkType: hard
-
 "object-inspect@npm:^1.13.3, object-inspect@npm:^1.13.4":
   version: 1.13.4
   resolution: "object-inspect@npm:1.13.4"
@@ -9261,18 +8734,6 @@ __metadata:
   version: 1.1.1
   resolution: "object-keys@npm:1.1.1"
   checksum: b363c5e7644b1e1b04aa507e88dcb8e3a2f52b6ffd0ea801e4c7a62d5aa559affe21c55a07fd4b1fd55fc03a33c610d73426664b20032405d7b92a1414c34d6a
-  languageName: node
-  linkType: hard
-
-"object.assign@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "object.assign@npm:4.1.2"
-  dependencies:
-    call-bind: ^1.0.0
-    define-properties: ^1.1.3
-    has-symbols: ^1.0.1
-    object-keys: ^1.1.1
-  checksum: d621d832ed7b16ac74027adb87196804a500d80d9aca536fccb7ba48d33a7e9306a75f94c1d29cbfa324bc091bfc530bc24789568efdaee6a47fcfa298993814
   languageName: node
   linkType: hard
 
@@ -9314,18 +8775,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.values@npm:^1.1.5":
-  version: 1.1.5
-  resolution: "object.values@npm:1.1.5"
-  dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.3
-    es-abstract: ^1.19.1
-  checksum: 0f17e99741ebfbd0fa55ce942f6184743d3070c61bd39221afc929c8422c4907618c8da694c6915bc04a83ab3224260c779ba37fc07bb668bdc5f33b66a902a4
-  languageName: node
-  linkType: hard
-
-"object.values@npm:^1.1.6, object.values@npm:^1.2.1":
+"object.values@npm:^1.1.5, object.values@npm:^1.1.6, object.values@npm:^1.2.1":
   version: 1.2.1
   resolution: "object.values@npm:1.2.1"
   dependencies:
@@ -9346,7 +8796,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0":
+"once@npm:^1.3.0, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -9603,14 +9053,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "picocolors@npm:1.0.0"
-  checksum: a2e8092dd86c8396bdba9f2b5481032848525b3dc295ce9b57896f931e63fc16f79805144321f72976383fc249584672a75cc18d6777c6b757603f372f745981
-  languageName: node
-  linkType: hard
-
-"picocolors@npm:^1.1.1":
+"picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
@@ -9950,17 +9393,6 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.8.4
   checksum: 20b6f9377d65954980fe044cfdd160de98df415b4bff38fbade67b3337efaf078308c4fed943067cd759827cc8cfeca9cb28ccda1f08333b85d6a2acbd022c27
-  languageName: node
-  linkType: hard
-
-"regexp.prototype.flags@npm:^1.4.3":
-  version: 1.4.3
-  resolution: "regexp.prototype.flags@npm:1.4.3"
-  dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.3
-    functions-have-names: ^1.2.2
-  checksum: 51228bae732592adb3ededd5e15426be25f289e9c4ef15212f4da73f4ec3919b6140806374b8894036a86020d054a8d2657d3fee6bb9b4d35d8939c20030b7a6
   languageName: node
   linkType: hard
 
@@ -10488,17 +9920,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "side-channel@npm:1.0.4"
-  dependencies:
-    call-bind: ^1.0.0
-    get-intrinsic: ^1.0.2
-    object-inspect: ^1.9.0
-  checksum: 351e41b947079c10bd0858364f32bb3a7379514c399edb64ab3dce683933483fc63fb5e4efe0a15a2e8a7e3c436b6a91736ddb8d8c6591b0460a24bb4a1ee245
-  languageName: node
-  linkType: hard
-
 "side-channel@npm:^1.0.6, side-channel@npm:^1.1.0":
   version: 1.1.0
   resolution: "side-channel@npm:1.1.0"
@@ -10819,17 +10240,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string.prototype.trimend@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "string.prototype.trimend@npm:1.0.5"
-  dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.4
-    es-abstract: ^1.19.5
-  checksum: d44f543833112f57224e79182debadc9f4f3bf9d48a0414d6f0cbd2a86f2b3e8c0ca1f95c3f8e5b32ae83e91554d79d932fc746b411895f03f93d89ed3dfb6bc
-  languageName: node
-  linkType: hard
-
 "string.prototype.trimend@npm:^1.0.9":
   version: 1.0.9
   resolution: "string.prototype.trimend@npm:1.0.9"
@@ -10839,17 +10249,6 @@ __metadata:
     define-properties: ^1.2.1
     es-object-atoms: ^1.0.0
   checksum: cb86f639f41d791a43627784be2175daa9ca3259c7cb83e7a207a729909b74f2ea0ec5d85de5761e6835e5f443e9420c6ff3f63a845378e4a61dd793177bc287
-  languageName: node
-  linkType: hard
-
-"string.prototype.trimstart@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "string.prototype.trimstart@npm:1.0.5"
-  dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.4
-    es-abstract: ^1.19.5
-  checksum: a4857c5399ad709d159a77371eeaa8f9cc284469a0b5e1bfe405de16f1fd4166a8ea6f4180e55032f348d1b679b1599fd4301fbc7a8b72bdb3e795e43f7b1048
   languageName: node
   linkType: hard
 
@@ -10945,15 +10344,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^5.3.0":
-  version: 5.5.0
-  resolution: "supports-color@npm:5.5.0"
-  dependencies:
-    has-flag: ^3.0.0
-  checksum: 95f6f4ba5afdf92f495b5a912d4abee8dcba766ae719b975c56c084f5004845f6f5a5f7769f52d53f40e21952a6d87411bafe34af4a01e65f9926002e38e1dac
-  languageName: node
-  linkType: hard
-
 "supports-color@npm:^7.1.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
@@ -11039,13 +10429,6 @@ __metadata:
   version: 1.0.5
   resolution: "tmpl@npm:1.0.5"
   checksum: cd922d9b853c00fe414c5a774817be65b058d54a2d01ebb415840960406c669a0fc632f66df885e24cb022ec812739199ccbdb8d1164c3e513f85bfca5ab2873
-  languageName: node
-  linkType: hard
-
-"to-fast-properties@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "to-fast-properties@npm:2.0.0"
-  checksum: be2de62fe58ead94e3e592680052683b1ec986c72d589e7b21e5697f8744cdbf48c266fa72f6c15932894c10187b5f54573a3bcf7da0bfd964d5caf23d436168
   languageName: node
   linkType: hard
 
@@ -11245,18 +10628,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unbox-primitive@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "unbox-primitive@npm:1.0.2"
-  dependencies:
-    call-bind: ^1.0.2
-    has-bigints: ^1.0.2
-    has-symbols: ^1.0.3
-    which-boxed-primitive: ^1.0.2
-  checksum: b7a1cf5862b5e4b5deb091672ffa579aa274f648410009c81cca63fed3b62b610c4f3b773f912ce545bb4e31edc3138975b5bc777fc6e4817dca51affb6380e9
-  languageName: node
-  linkType: hard
-
 "unbox-primitive@npm:^1.1.0":
   version: 1.1.0
   resolution: "unbox-primitive@npm:1.1.0"
@@ -11406,24 +10777,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"universal-user-agent@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "universal-user-agent@npm:6.0.1"
+  checksum: fdc8e1ae48a05decfc7ded09b62071f571c7fe0bd793d700704c80cea316101d4eac15cc27ed2bb64f4ce166d2684777c3198b9ab16034f547abea0d3aa1c93c
+  languageName: node
+  linkType: hard
+
 "unpipe@npm:1.0.0, unpipe@npm:~1.0.0":
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 4fa18d8d8d977c55cb09715385c203197105e10a6d220087ec819f50cb68870f02942244f1017565484237f1f8c5d3cd413631b1ae104d3096f24fdfde1b4aa2
-  languageName: node
-  linkType: hard
-
-"update-browserslist-db@npm:^1.0.13":
-  version: 1.0.13
-  resolution: "update-browserslist-db@npm:1.0.13"
-  dependencies:
-    escalade: ^3.1.1
-    picocolors: ^1.0.0
-  peerDependencies:
-    browserslist: ">= 4.21.0"
-  bin:
-    update-browserslist-db: cli.js
-  checksum: 1e47d80182ab6e4ad35396ad8b61008ae2a1330221175d0abd37689658bdb61af9b705bfc41057fd16682474d79944fb2d86767c5ed5ae34b6276b9bed353322
   languageName: node
   linkType: hard
 
@@ -11586,19 +10950,6 @@ __metadata:
   dependencies:
     makeerror: 1.0.12
   checksum: ad7a257ea1e662e57ef2e018f97b3c02a7240ad5093c392186ce0bcf1f1a60bbadd520d073b9beb921ed99f64f065efb63dfc8eec689a80e569f93c1c5d5e16c
-  languageName: node
-  linkType: hard
-
-"which-boxed-primitive@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "which-boxed-primitive@npm:1.0.2"
-  dependencies:
-    is-bigint: ^1.0.1
-    is-boolean-object: ^1.1.0
-    is-number-object: ^1.0.4
-    is-string: ^1.0.5
-    is-symbol: ^1.0.3
-  checksum: 53ce774c7379071729533922adcca47220228405e1895f26673bbd71bdf7fb09bee38c1d6399395927c6289476b5ae0629863427fd151491b71c4b6cb04f3a5e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2327,7 +2327,13 @@ __metadata:
     yaml: ^2.2.2
     yargs: ^17.7.1
   peerDependencies:
+    oxfmt: ^0.45.0
     prettier: ">=3.0.0"
+  peerDependenciesMeta:
+    oxfmt:
+      optional: true
+    prettier:
+      optional: true
   bin:
     create-release-branch: bin/create-release-branch.js
   languageName: unknown


### PR DESCRIPTION
This adds a new optional `--formatter` option to the CLI, which can be set to either "oxfmt" or "prettier" (default). This allows the generated changelog to be formatted with Oxfmt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release workflow to thread a new `formatter` parameter through changelog generation/execution paths and upgrades `@metamask/auto-changelog`, which could alter changelog output or release-branch automation behavior.
> 
> **Overview**
> Adds a new `--formatter` CLI option (default `prettier`) to control how changelogs are formatted, supporting both `prettier` and `oxfmt` across the CLI and interactive UI workflows.
> 
> Threads this formatter selection through `determineInitialParameters`, `followMonorepoWorkflow`/UI execution, and `executeReleasePlan`/package update helpers, replacing the previous hardcoded Prettier formatting with a `getFormatter` switch.
> 
> Updates dependencies to `@metamask/auto-changelog@^6.1.0`, adds optional peer deps for `oxfmt`/`prettier`, and adjusts tests (including mocking dynamic imports) plus a new Oxfmt-specific changelog expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8624d541cd16536539679a9acdcf57de0bff17d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->